### PR TITLE
Rework bootstrapping for py2/py3 and arch specific deps

### DIFF
--- a/hooks/config-changed
+++ b/hooks/config-changed
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-
-# Load modules from $CHARM_DIR/lib
-import sys
-sys.path.append('lib')
-
-# This will load and run the appropriate @hook and other decorated
-# handlers from $CHARM_DIR/reactive, $CHARM_DIR/hooks/reactive,
-# and $CHARM_DIR/hooks/relations.
-#
-# See https://jujucharms.com/docs/stable/getting-started-with-charms-reactive
-# for more information on this pattern.
-from charms.reactive import main
-main()
+#!/bin/sh -e
+exec env JUJU_HOOK_NAME=${JUJU_HOOK_NAME:=`basename $0`} \
+    ${CHARM_DIR}/hooks/default-hook.sh

--- a/hooks/default-hook.sh
+++ b/hooks/default-hook.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+if (which python3 > /dev/null); then
+    PYTHON=python3
+elif (which python > /dev/null); then
+    PYTHON=python
+else
+    PYTHON=python3
+    apt-get install -y python3
+fi
+
+# Architecture dependent Python modules that need to be installed as
+# debs. Pure Python packages should be preferred and embedded.
+imports="
+import yaml;
+import tempita;
+import apt;
+import distro_info;
+"
+packages="
+${PYTHON}-yaml
+${PYTHON}-tempita
+${PYTHON}-apt
+${PYTHON}-distro-info
+"
+if ! ($PYTHON -c "${imports}" 2>/dev/null); then
+    apt-get install -y ${packages}
+fi
+
+# The version of Python to be used to run hooks and actions is
+# configured with the executable key in layer.yaml
+PYTHON=`python -c "
+import os;
+import yaml;
+layer = yaml.load(open('${CHARM_DIR}/layer.yaml'))
+print(layer.get('executable', '${PYTHON}'))
+"`
+
+exec env JUJU_HOOK_NAME=${JUJU_HOOK_NAME:=`basename $0`} ${PYTHON} <<SCRIPT
+import os
+import sys
+
+# Load modules from $CHARM_DIR/lib
+sys.path.append(os.path.join(os.environ['CHARM_DIR'], 'lib'))
+
+# This will load and run the appropriate @hook and other decorated
+# handlers from $CHARM_DIR/reactive, $CHARM_DIR/hooks/reactive,
+# and $CHARM_DIR/hooks/relations.
+#
+# See https://jujucharms.com/docs/stable/getting-started-with-charms-reactive
+# for more information on this pattern.
+from charms.reactive import main
+main()
+SCRIPT

--- a/hooks/install
+++ b/hooks/install
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-
-# Load modules from $CHARM_DIR/lib
-import sys
-sys.path.append('lib')
-
-# This will load and run the appropriate @hook and other decorated
-# handlers from $CHARM_DIR/reactive, $CHARM_DIR/hooks/reactive,
-# and $CHARM_DIR/hooks/relations.
-#
-# See https://jujucharms.com/docs/stable/getting-started-with-charms-reactive
-# for more information on this pattern.
-from charms.reactive import main
-main()
+#!/bin/sh -e
+exec env JUJU_HOOK_NAME=${JUJU_HOOK_NAME:=`basename $0`} \
+    ${CHARM_DIR}/hooks/default-hook.sh

--- a/hooks/start
+++ b/hooks/start
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-
-# Load modules from $CHARM_DIR/lib
-import sys
-sys.path.append('lib')
-
-# This will load and run the appropriate @hook and other decorated
-# handlers from $CHARM_DIR/reactive, $CHARM_DIR/hooks/reactive,
-# and $CHARM_DIR/hooks/relations.
-#
-# See https://jujucharms.com/docs/stable/getting-started-with-charms-reactive
-# for more information on this pattern.
-from charms.reactive import main
-main()
+#!/bin/sh -e
+exec env JUJU_HOOK_NAME=${JUJU_HOOK_NAME:=`basename $0`} \
+    ${CHARM_DIR}/hooks/default-hook.sh

--- a/hooks/stop
+++ b/hooks/stop
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-
-# Load modules from $CHARM_DIR/lib
-import sys
-sys.path.append('lib')
-
-# This will load and run the appropriate @hook and other decorated
-# handlers from $CHARM_DIR/reactive, $CHARM_DIR/hooks/reactive,
-# and $CHARM_DIR/hooks/relations.
-#
-# See https://jujucharms.com/docs/stable/getting-started-with-charms-reactive
-# for more information on this pattern.
-from charms.reactive import main
-main()
+#!/bin/sh -e
+exec env JUJU_HOOK_NAME=${JUJU_HOOK_NAME:=`basename $0`} \
+    ${CHARM_DIR}/hooks/default-hook.sh

--- a/hooks/upgrade-charm
+++ b/hooks/upgrade-charm
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-
-# Load modules from $CHARM_DIR/lib
-import sys
-sys.path.append('lib')
-
-# This will load and run the appropriate @hook and other decorated
-# handlers from $CHARM_DIR/reactive, $CHARM_DIR/hooks/reactive,
-# and $CHARM_DIR/hooks/relations.
-#
-# See https://jujucharms.com/docs/stable/getting-started-with-charms-reactive
-# for more information on this pattern.
-from charms.reactive import main
-main()
+#!/bin/sh -e
+exec env JUJU_HOOK_NAME=${JUJU_HOOK_NAME:=`basename $0`} \
+    ${CHARM_DIR}/hooks/default-hook.sh


### PR DESCRIPTION
Here is an exploration of an alternative bootstrap mechanism. While this is proof that this can work, its all rather horrible and magic and I suspect we will want alternative alternative mechanisms.

The user may specify the python executable to use in layer.yaml

```yaml
executable: python3
```

The hook stubs become minimal shell scripts, each invoke a rather larger and even ugly shell script. They calculate and pass in JUJU_HOOK_NAME, as the original executable name is about to get lost.

The bigger script (default-hook.sh) first detects if it has python2 or python3 available (and installs python3 if neither are available, not that we will see that).
Next up it attempts to import the dependencies containing C extensions or linking with system libraries, and installs the necessary packages if any are missing.
Finally, it calls the original Python stub code to kick off the reactor, again passing in JUJU_HOOK_NAME so it isn't lost.

This is all rather horrible, but one of the few ways I can think of meeting all our needs without needing features added to Juju.

A much simpler way of handling the python version is to munge the shebang lines of hooks and actions at 'charm build' time.

A simpler way of getting debs installed is the try: except ImportError mechanism currently used by charmhelpers.