### PR TITLE
Fix lint make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build: unit_test
 	juju-compose -o ~/charms .
 
 lint:
-	@flake8 --exclude hooks/charmhelpers hooks unit_tests tests
+	@flake8 $(wildcard hooks unit_tests tests)
 	@charm proof
 
 unit_test:


### PR DESCRIPTION
`make lint` will fail if not all of the directories are present.  Also, the `--exclude hooks/charmhelpers` is no longer needed, with charmhelpers being in the wheelhouse.