### PR TITLE
config.changed* should fire unconditionally on charm upgrade

### DIFF
--- a/hooks/upgrade-charm
+++ b/hooks/upgrade-charm
@@ -15,7 +15,7 @@ else:
 
 from charms.layer import basic
 basic.bootstrap_charm_deps()
-basic.init_config_states()
+basic.init_config_states(upgrade=True)
 
 
 # This will load and run the appropriate @hook and other decorated

--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -93,12 +93,12 @@ def apt_install(packages):
     check_call(cmd + packages, env=env)
 
 
-def init_config_states():
+def init_config_states(upgrade=False):
     from charmhelpers.core import hookenv
     from charms.reactive import set_state
     config = hookenv.config()
     for opt in config.keys():
-        if config.changed(opt):
+        if config.changed(opt) or upgrade:
             set_state('config.changed')
             set_state('config.changed.{}'.format(opt))
     hookenv.atexit(clear_config_states)


### PR DESCRIPTION
When a charm is upgraded which has no config-changed hook, but depends only on a reactive config.changed* handler, there may be templates which need regenerating based on the configuration settings, but those settings themselves have not changed.  This is an untested suggestion for causing the config.changed* reactive state to occur on charm upgrade.  Thoughts?