### PR TITLE
Remove failing `make test` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,3 @@ lint:
 unit_test:
 	@echo Starting tests...
 	tox
-
-test:
-	@echo Starting Amulet tests...
-	# coreycb note: The -v should only be temporary until Amulet sends
-	# raise_status() messages to stderr:
-	#   https://bugs.launchpad.net/amulet/+bug/1320357
-	@juju test -v -p AMULET_HTTP_PROXY,AMULET_OS_VIP --timeout 2700


### PR DESCRIPTION
Bundletester will discover and run Amulet tests and `juju test` is defunct.  This was causing spurious failures.