### PR TITLE
Remove non-useful build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,6 @@ PYTHON := /usr/bin/env python
 all: lint test build
 
 
-build: unit_test
-	juju-compose -o ~/charms .
-
 lint:
 	@flake8 $(wildcard hooks unit_tests tests)
 	@charm proof


### PR DESCRIPTION
The build target should only be run from the charm (source) layer, so having it in the base layer is pointless.  It belongs in the reactive charm template.