### PR TITLE
Fix use_venv on restricted-network environments

### DIFF
--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -32,7 +32,7 @@ def bootstrap_charm_deps():
         if cfg.get('use_venv'):
             if not os.path.exists(venv):
                 apt_install(['python-virtualenv'])
-                cmd = ['virtualenv', '--python=python3', venv]
+                cmd = ['virtualenv', '-p=python3', '--never-download', venv]
                 if cfg.get('include_system_packages'):
                     cmd.append('--system-site-packages')
                 check_call(cmd)


### PR DESCRIPTION
Creating venvs in network-restricted environments (on Xenial, at least) attempts to pull `setuptools` and `wheel` from pypi.  Per pypa/virtualenv#412 `--never-download` is to be set by default to address this, but isn't yet in the packaged versions, so we need to add it manually.