### PR TITLE
Fix virtualenv for xenial

### DIFF
--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import shutil
+import platform
 from glob import glob
 from subprocess import check_call
 
@@ -50,7 +51,11 @@ def bootstrap_charm_deps():
         # if we're using a venv, set it up
         if cfg.get('use_venv'):
             if not os.path.exists(venv):
-                apt_install(['python-virtualenv'])
+                distname, version, series = platform.linux_distribution()
+                if series in ('precise', 'trusty'):
+                    apt_install(['python-virtualenv'])
+                else:
+                    apt_install(['virtualenv'])
                 cmd = ['virtualenv', '-ppython3', '--never-download', venv]
                 if cfg.get('include_system_packages'):
                     cmd.append('--system-site-packages')


### PR DESCRIPTION
In Xenial, the `python-virtualenv` package was split in to three different packages: `python-virtualenv`, `python3-virtualenv`, and `virtualenv` with the latter installing the actual CLI command.  Unfortunately, `python-virtualenv` only recommends `virtualenv` so we have to manually install it on Xenial.  It also doesn't exist on trusty, so that's fun.