### PR TITLE
Add Xenial's Python version to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist = py34
+envlist = py{3.4,3.5}
 
 [testenv]
 commands = py.test -v


### PR DESCRIPTION
Trusty uses py3.4 and Xenial uses py3.5.  If we specify both and one is
missing on a given system, it should be ignored.