### PR TITLE
allow python 3.5 to be used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ apt_prereqs:
 
 lint: apt_prereqs
 	@tox --notest
-	@.tox/py34/bin/flake8 $(wildcard hooks reactive lib unit_tests tests)
+	@PATH=`pwd`/.tox/py34/bin:`pwd`/.tox/py35/bin flake8 $(wildcard hooks reactive lib unit_tests tests)
 	@charm proof
 
 unit_test: apt_prereqs

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ all: lint unit_test
 .PHONY: apt_prereqs
 apt_prereqs:
 	@# Need tox, but don't install the apt version unless we have to (don't want to conflict with pip)
-	@which tox >/dev/null || sudo apt-get install -y python-tox
+	@which tox >/dev/null || sudo apt-get install -y python-pip && sudo pip install tox
 
 lint: apt_prereqs
 	@tox --notest

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 skipsdist=True
-envlist = py34
+envlist = py34, py35
+skip_missing_interpreters = True
 
 [testenv]
 commands = py.test -v


### PR DESCRIPTION
This lets us use python 3.4 or python 3.5, and sets up the PATH for flake8