### PR TITLE
Added config.non-default.X state

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ This layer will set the following states:
     `config.yaml`.  This state is cleared automatically at the end of each hook
     invocation.
 
+  * **`config.default.<option>`** A specific config option is set to its
+    default value.  **`<option>`** will be replaced by the config option name
+    from `config.yaml`.  This state is cleared automatically at the end of
+    each hook invocation.
+
 An example using the config states would be:
 
 ```python

--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import shutil
+import yaml
 from glob import glob
 from subprocess import check_call
 
@@ -121,11 +122,20 @@ def init_config_states():
     from charms.reactive import set_state
     from charms.reactive import toggle_state
     config = hookenv.config()
+    config_defaults = {}
+    config_yaml = os.path.join(hookenv.charm_dir(), 'config.yaml')
+    if os.path.exists(config_yaml):
+        with open(config_yaml) as fp:
+            config_defs = yaml.load(fp).get('options', {})
+            config_defaults = {key: value.get('default')
+                               for key, value in config_defs.items()}
     for opt in config.keys():
         if config.changed(opt):
             set_state('config.changed')
             set_state('config.changed.{}'.format(opt))
         toggle_state('config.set.{}'.format(opt), config[opt])
+        toggle_state('config.default.{}'.format(opt),
+                     config[opt] == config_defaults[opt])
     hookenv.atexit(clear_config_states)
 
 
@@ -137,4 +147,5 @@ def clear_config_states():
     for opt in config.keys():
         remove_state('config.changed.{}'.format(opt))
         remove_state('config.set.{}'.format(opt))
+        remove_state('config.default.{}'.format(opt))
     unitdata.kv().flush()


### PR DESCRIPTION
New state to detect if a config option has been changed from its default value.  (Arguably, that's what `config.set.X` should have done from the beginning, as it seems the more useful case, but having both isn't bad.)

I'm open to bike shedding on the state name.