### PR TITLE
Add CLI for layer options

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,26 @@ def do_thing():
       hookenv.log("Bar is enabled")
 ```
 
+You can also access layer options in other handlers, such as Bash, using
+the command-line interface:
+
+```bash
+. charms.reactive.sh
+
+@when 'state'
+function do_thing() {
+    if layer_option foo enable-bar; then
+        juju-log "Bar is enabled"
+        juju-log "bar-value is: $(layer_option foo bar-value)"
+    fi
+}
+
+reactive_handler_main
+```
+
+Note that options of type `boolean` will set the exit code, while other types
+will be printed out.
+
 # Hooks
 
 This layer provides hooks that other layers can react to using the decorators

--- a/bin/layer_option
+++ b/bin/layer_option
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+import sys
+sys.path.append('lib')
+
+import argparse
+from charms.layer import options
+
+
+parser = argparse.ArgumentParser(description='Access layer options.')
+parser.add_argument('section',
+                    help='the section, or layer, the option is from')
+parser.add_argument('option',
+                    help='the option to access')
+
+args = parser.parse_args()
+value = options(args.section).get(args.option, '')
+if isinstance(value, bool):
+    sys.exit(0 if value else 1)
+elif isinstance(value, list):
+    for val in value:
+        print(val)
+else:
+    print(value)

--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -17,6 +17,8 @@ def bootstrap_charm_deps():
     # and the charm itself can actually succeed. This call does nothing
     # unless the operator has created and populated $CHARM_DIR/exec.d.
     execd_preinstall()
+    # ensure that $CHARM_DIR/bin is on the path, for helper scripts
+    os.environ['PATH'] += ':%s' % os.path.join(os.environ['CHARM_DIR'], 'bin')
     venv = os.path.abspath('../.venv')
     vbin = os.path.join(venv, 'bin')
     vpip = os.path.join(vbin, 'pip')


### PR DESCRIPTION
```bash
. charms.reactive.sh

@when 'state'
function do_thing() {
    if layer_option foo enable-bar; then
        juju-log "Bar is enabled"
        juju-log "bar-value is: $(layer_option foo bar-value)"
        for val in $(layer_option foo arr-value); do
            juju-log "val: $val"
        done
    fi
}

reactive_handler_main
```