### PR TITLE
Revert "Added config.non-default.X state"

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,11 +187,6 @@ This layer will set the following states:
     `config.yaml`.  This state is cleared automatically at the end of each hook
     invocation.
 
-  * **`config.default.<option>`** A specific config option is set to its
-    default value.  **`<option>`** will be replaced by the config option name
-    from `config.yaml`.  This state is cleared automatically at the end of
-    each hook invocation.
-
 An example using the config states would be:
 
 ```python

--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import shutil
-import yaml
 from glob import glob
 from subprocess import check_call
 
@@ -124,20 +123,11 @@ def init_config_states():
     from charms.reactive import set_state
     from charms.reactive import toggle_state
     config = hookenv.config()
-    config_defaults = {}
-    config_yaml = os.path.join(hookenv.charm_dir(), 'config.yaml')
-    if os.path.exists(config_yaml):
-        with open(config_yaml) as fp:
-            config_defs = yaml.load(fp).get('options', {})
-            config_defaults = {key: value.get('default')
-                               for key, value in config_defs.items()}
     for opt in config.keys():
         if config.changed(opt):
             set_state('config.changed')
             set_state('config.changed.{}'.format(opt))
         toggle_state('config.set.{}'.format(opt), config[opt])
-        toggle_state('config.default.{}'.format(opt),
-                     config[opt] == config_defaults[opt])
     hookenv.atexit(clear_config_states)
 
 
@@ -149,5 +139,4 @@ def clear_config_states():
     for opt in config.keys():
         remove_state('config.changed.{}'.format(opt))
         remove_state('config.set.{}'.format(opt))
-        remove_state('config.default.{}'.format(opt))
     unitdata.kv().flush()


### PR DESCRIPTION
Reverts juju-solutions/layer-basic#57

Import yaml is failing on trusty. Reverting until we fix this in the PR 

unit-sparkb-0[3311]: 2016-04-22 17:22:41 INFO unit.sparkb/0.install logger.go:40   File "lib/charms/layer/basic.py", line 4, in <module>
unit-sparkb-0[3311]: 2016-04-22 17:22:41 INFO unit.sparkb/0.install logger.go:40     import yaml
unit-sparkb-0[3311]: 2016-04-22 17:22:41 INFO unit.sparkb/0.install logger.go:40 ImportError: No module named 'yaml'
u