### PR TITLE
Standard action entry point template and action state

### DIFF
--- a/actions/action.template
+++ b/actions/action.template
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+# Load modules from $CHARM_DIR/lib
+import sys
+sys.path.append('lib')  # noqa
+
+import traceback
+
+from charms.layer.basic import init_action_states
+from charms.reactive import main
+from charmhelpers.core import hookenv
+
+if __name__ == '__main__':
+    try:
+        action_name = hookenv.action_name()
+        hookenv.log('Running action {} ({})'.format(action_name,
+                                                    hookenv.action_uuid()))
+
+        # Set the action.{name} state, allowing you to specify standard
+        # handlers run only in the action, or never during the action.
+        init_action_states()
+
+        # This will load and run the appropriate @action and other decorated
+        # handlers from $CHARM_DIR/reactive, $CHARM_DIR/hooks/reactive,
+        # and $CHARM_DIR/hooks/relations.
+        #
+        # See https://jujucharms.com/docs/stable/authors-charm-building
+        # for more information on this pattern.
+        main()
+    except Exception:
+        hookenv.action_fail('Unhandled exception')
+        hookenv.action_set(dict(traceback=traceback.format_exc()))
+        raise

--- a/actions/action.template
+++ b/actions/action.template
@@ -6,7 +6,6 @@ sys.path.append('lib')  # noqa
 
 import traceback
 
-from charms.layer.basic import init_action_states
 from charms.reactive import main
 from charmhelpers.core import hookenv
 
@@ -15,10 +14,6 @@ if __name__ == '__main__':
         action_name = hookenv.action_name()
         hookenv.log('Running action {} ({})'.format(action_name,
                                                     hookenv.action_uuid()))
-
-        # Set the action.{name} state, allowing you to specify standard
-        # handlers run only in the action, or never during the action.
-        init_action_states()
 
         # This will load and run the appropriate @action and other decorated
         # handlers from $CHARM_DIR/reactive, $CHARM_DIR/hooks/reactive,

--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -152,3 +152,22 @@ def clear_config_states():
         remove_state('config.set.{}'.format(opt))
         remove_state('config.default.{}'.format(opt))
     unitdata.kv().flush()
+
+
+def init_action_states():
+    from charmhelpers.core import hookenv, unitdata
+    from charms.reactive.bus import get_states, set_state, remove_state
+
+    action_state = 'action.{}'.format(hookenv.action_name())
+    set_state(action_state)
+
+    # Remove any previously set action states. They should not exist,
+    # but they might. We flush unitdata twice, and a failure between
+    # them will leave unexpected states set.
+    for state in get_states():
+        if state != action_state and state.startswith('action.'):
+            remove_state(state)
+
+    # These are run in the reverse order they are added.
+    hookenv.atexit(unitdata.kv().flush)
+    hookenv.atexit(remove_state, action_state)

--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -152,22 +152,3 @@ def clear_config_states():
         remove_state('config.set.{}'.format(opt))
         remove_state('config.default.{}'.format(opt))
     unitdata.kv().flush()
-
-
-def init_action_states():
-    from charmhelpers.core import hookenv, unitdata
-    from charms.reactive.bus import get_states, set_state, remove_state
-
-    action_state = 'action.{}'.format(hookenv.action_name())
-    set_state(action_state)
-
-    # Remove any previously set action states. They should not exist,
-    # but they might. We flush unitdata twice, and a failure between
-    # them will leave unexpected states set.
-    for state in get_states():
-        if state != action_state and state.startswith('action.'):
-            remove_state(state)
-
-    # These are run in the reverse order they are added.
-    hookenv.atexit(unitdata.kv().flush)
-    hookenv.atexit(remove_state, action_state)


### PR DESCRIPTION
This branch adds the standard entry point template for charms.reactive actions, to work with https://github.com/juju-solutions/charms.reactive/pull/66

I was considering adding the action parameters from action-get to the state so they got passed in as an argument to the handlers, but decided against it as I think that feature is specific to relations. I think it is doable, but someone more familiar would need to confirm it is the right thing to do.

The action.\* states went in here, because this is where we are setting the config.\* states. It means they can be turned off (eg. a layer option could be added), but we don't have a test harness in place for this basic layer that is becoming less basic and more featureful.
