### PR TITLE
bump pip version range

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,3 +1,3 @@
-pip>=7.0.0,<8.0.0
+pip>=7.0.0,<8.2.0
 charmhelpers>=0.4.0,<1.0.0
 charms.reactive>=0.1.0,<2.0.0


### PR DESCRIPTION
It looks like something was pulling in pip 8.1.1 before we get to handling the wheelhouse, causing the attempted install of pip 7.1.2 to fail:

```
unit-openvim-controller-0: 2016-05-25 18:31:45 INFO unit.openvim-controller/0.install logger.go:40 Processing ./wheelhouse/pip-7.1.2.tar.gz
unit-openvim-controller-0: 2016-05-25 18:31:45 INFO unit.openvim-controller/0.install logger.go:40 Exception:
unit-openvim-controller-0: 2016-05-25 18:31:45 INFO unit.openvim-controller/0.install logger.go:40 Traceback (most recent call last):
unit-openvim-controller-0: 2016-05-25 18:31:45 INFO unit.openvim-controller/0.install logger.go:40   File "/usr/lib/python3/dist-packages/pip/req/req_install.py", line 1006, in check_if_exists
unit-openvim-controller-0: 2016-05-25 18:31:45 INFO unit.openvim-controller/0.install logger.go:40     self.satisfied_by = pkg_resources.get_distribution(str(no_marker))
unit-openvim-controller-0: 2016-05-25 18:31:45 INFO unit.openvim-controller/0.install logger.go:40   File "/usr/share/python-wheels/pkg_resources-0.0.0-py2.py3-none-any.whl/pkg_resources/__init__.py", line 535, in get_distribution
unit-openvim-controller-0: 2016-05-25 18:31:45 INFO unit.openvim-controller/0.install logger.go:40     dist = get_provider(dist)
unit-openvim-controller-0: 2016-05-25 18:31:45 INFO unit.openvim-controller/0.install logger.go:40   File "/usr/share/python-wheels/pkg_resources-0.0.0-py2.py3-none-any.whl/pkg_resources/__init__.py", line 415, in get_provider
unit-openvim-controller-0: 2016-05-25 18:31:45 INFO unit.openvim-controller/0.install logger.go:40     return working_set.find(moduleOrReq) or require(str(moduleOrReq))[0]
unit-openvim-controller-0: 2016-05-25 18:31:45 INFO unit.openvim-controller/0.install logger.go:40   File "/usr/share/python-wheels/pkg_resources-0.0.0-py2.py3-none-any.whl/pkg_resources/__init__.py", line 695, in find
unit-openvim-controller-0: 2016-05-25 18:31:45 INFO unit.openvim-controller/0.install logger.go:40     raise VersionConflict(dist, req)
unit-openvim-controller-0: 2016-05-25 18:31:45 INFO unit.openvim-controller/0.install logger.go:40 pkg_resources.VersionConflict: (pip 8.1.1 (/usr/lib/python3/dist-packages), Requirement.parse('pip===7.1.2'))
```