### PR TITLE
Use JUJU_CHARM_DIR environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ This layer supports the following options, which can be set in `layer.yaml`:
 
   * **use_venv**  If set to true, the charm dependencies from the various
     layers' `wheelhouse.txt` files will be installed in a Python virtualenv
-    located at `$CHARM_DIR/../.venv`.  This keeps charm dependencies from
+    located at `$JUJU_CHARM_DIR/../.venv`.  This keeps charm dependencies from
     conflicting with payload dependencies, but you must take care to preserve
     the environment and interpreter if using `execl` or `subprocess`.
 

--- a/hooks/config-changed
+++ b/hooks/config-changed
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Load modules from $CHARM_DIR/lib
+# Load modules from $JUJU_CHARM_DIR/lib
 import sys
 sys.path.append('lib')
 
@@ -10,8 +10,8 @@ basic.init_config_states()
 
 
 # This will load and run the appropriate @hook and other decorated
-# handlers from $CHARM_DIR/reactive, $CHARM_DIR/hooks/reactive,
-# and $CHARM_DIR/hooks/relations.
+# handlers from $JUJU_CHARM_DIR/reactive, $JUJU_CHARM_DIR/hooks/reactive,
+# and $JUJU_CHARM_DIR/hooks/relations.
 #
 # See https://jujucharms.com/docs/stable/authors-charm-building
 # for more information on this pattern.

--- a/hooks/hook.template
+++ b/hooks/hook.template
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Load modules from $CHARM_DIR/lib
+# Load modules from $JUJU_CHARM_DIR/lib
 import sys
 sys.path.append('lib')
 
@@ -10,8 +10,8 @@ basic.init_config_states()
 
 
 # This will load and run the appropriate @hook and other decorated
-# handlers from $CHARM_DIR/reactive, $CHARM_DIR/hooks/reactive,
-# and $CHARM_DIR/hooks/relations.
+# handlers from $JUJU_CHARM_DIR/reactive, $JUJU_CHARM_DIR/hooks/reactive,
+# and $JUJU_CHARM_DIR/hooks/relations.
 #
 # See https://jujucharms.com/docs/stable/authors-charm-building
 # for more information on this pattern.

--- a/hooks/install
+++ b/hooks/install
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Load modules from $CHARM_DIR/lib
+# Load modules from $JUJU_CHARM_DIR/lib
 import sys
 sys.path.append('lib')
 
@@ -10,8 +10,8 @@ basic.init_config_states()
 
 
 # This will load and run the appropriate @hook and other decorated
-# handlers from $CHARM_DIR/reactive, $CHARM_DIR/hooks/reactive,
-# and $CHARM_DIR/hooks/relations.
+# handlers from $JUJU_CHARM_DIR/reactive, $JUJU_CHARM_DIR/hooks/reactive,
+# and $JUJU_CHARM_DIR/hooks/relations.
 #
 # See https://jujucharms.com/docs/stable/authors-charm-building
 # for more information on this pattern.

--- a/hooks/leader-elected
+++ b/hooks/leader-elected
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Load modules from $CHARM_DIR/lib
+# Load modules from $JUJU_CHARM_DIR/lib
 import sys
 sys.path.append('lib')
 
@@ -10,8 +10,8 @@ basic.init_config_states()
 
 
 # This will load and run the appropriate @hook and other decorated
-# handlers from $CHARM_DIR/reactive, $CHARM_DIR/hooks/reactive,
-# and $CHARM_DIR/hooks/relations.
+# handlers from $JUJU_CHARM_DIR/reactive, $JUJU_CHARM_DIR/hooks/reactive,
+# and $JUJU_CHARM_DIR/hooks/relations.
 #
 # See https://jujucharms.com/docs/stable/authors-charm-building
 # for more information on this pattern.

--- a/hooks/leader-settings-changed
+++ b/hooks/leader-settings-changed
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Load modules from $CHARM_DIR/lib
+# Load modules from $JUJU_CHARM_DIR/lib
 import sys
 sys.path.append('lib')
 
@@ -10,8 +10,8 @@ basic.init_config_states()
 
 
 # This will load and run the appropriate @hook and other decorated
-# handlers from $CHARM_DIR/reactive, $CHARM_DIR/hooks/reactive,
-# and $CHARM_DIR/hooks/relations.
+# handlers from $JUJU_CHARM_DIR/reactive, $JUJU_CHARM_DIR/hooks/reactive,
+# and $JUJU_CHARM_DIR/hooks/relations.
 #
 # See https://jujucharms.com/docs/stable/authors-charm-building
 # for more information on this pattern.

--- a/hooks/start
+++ b/hooks/start
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Load modules from $CHARM_DIR/lib
+# Load modules from $JUJU_CHARM_DIR/lib
 import sys
 sys.path.append('lib')
 
@@ -10,8 +10,8 @@ basic.init_config_states()
 
 
 # This will load and run the appropriate @hook and other decorated
-# handlers from $CHARM_DIR/reactive, $CHARM_DIR/hooks/reactive,
-# and $CHARM_DIR/hooks/relations.
+# handlers from $JUJU_CHARM_DIR/reactive, $JUJU_CHARM_DIR/hooks/reactive,
+# and $JUJU_CHARM_DIR/hooks/relations.
 #
 # See https://jujucharms.com/docs/stable/authors-charm-building
 # for more information on this pattern.

--- a/hooks/stop
+++ b/hooks/stop
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Load modules from $CHARM_DIR/lib
+# Load modules from $JUJU_CHARM_DIR/lib
 import sys
 sys.path.append('lib')
 
@@ -10,8 +10,8 @@ basic.init_config_states()
 
 
 # This will load and run the appropriate @hook and other decorated
-# handlers from $CHARM_DIR/reactive, $CHARM_DIR/hooks/reactive,
-# and $CHARM_DIR/hooks/relations.
+# handlers from $JUJU_CHARM_DIR/reactive, $JUJU_CHARM_DIR/hooks/reactive,
+# and $JUJU_CHARM_DIR/hooks/relations.
 #
 # See https://jujucharms.com/docs/stable/authors-charm-building
 # for more information on this pattern.

--- a/hooks/update-status
+++ b/hooks/update-status
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Load modules from $CHARM_DIR/lib
+# Load modules from $JUJU_CHARM_DIR/lib
 import sys
 sys.path.append('lib')
 
@@ -10,8 +10,8 @@ basic.init_config_states()
 
 
 # This will load and run the appropriate @hook and other decorated
-# handlers from $CHARM_DIR/reactive, $CHARM_DIR/hooks/reactive,
-# and $CHARM_DIR/hooks/relations.
+# handlers from $JUJU_CHARM_DIR/reactive, $JUJU_CHARM_DIR/hooks/reactive,
+# and $JUJU_CHARM_DIR/hooks/relations.
 #
 # See https://jujucharms.com/docs/stable/authors-charm-building
 # for more information on this pattern.

--- a/hooks/upgrade-charm
+++ b/hooks/upgrade-charm
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Load modules from $CHARM_DIR/lib
+# Load modules from $JUJU_CHARM_DIR/lib
 import os
 import sys
 sys.path.append('lib')
@@ -19,8 +19,8 @@ basic.init_config_states()
 
 
 # This will load and run the appropriate @hook and other decorated
-# handlers from $CHARM_DIR/reactive, $CHARM_DIR/hooks/reactive,
-# and $CHARM_DIR/hooks/relations.
+# handlers from $JUJU_CHARM_DIR/reactive, $JUJU_CHARM_DIR/hooks/reactive,
+# and $JUJU_CHARM_DIR/hooks/relations.
 #
 # See https://jujucharms.com/docs/stable/authors-charm-building
 # for more information on this pattern.

--- a/lib/charms/layer/__init__.py
+++ b/lib/charms/layer/__init__.py
@@ -15,7 +15,7 @@ class LayerOptions(dict):
 
 def options(section=None, layer_file=None):
     if not layer_file:
-        base_dir = os.environ.get('CHARM_DIR', os.getcwd())
+        base_dir = os.environ.get('JUJU_CHARM_DIR', os.getcwd())
         layer_file = os.path.join(base_dir, 'layer.yaml')
 
     return LayerOptions(layer_file, section)

--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -26,10 +26,11 @@ def bootstrap_charm_deps():
     # access the network, because sites use this hook to do bespoke
     # configuration and install secrets so the rest of this bootstrap
     # and the charm itself can actually succeed. This call does nothing
-    # unless the operator has created and populated $CHARM_DIR/exec.d.
+    # unless the operator has created and populated $JUJU_CHARM_DIR/exec.d.
     execd_preinstall()
-    # ensure that $CHARM_DIR/bin is on the path, for helper scripts
-    os.environ['PATH'] += ':%s' % os.path.join(os.environ['CHARM_DIR'], 'bin')
+    # ensure that $JUJU_CHARM_DIR/bin is on the path, for helper scripts
+    charm_dir = os.environ['JUJU_CHARM_DIR']
+    os.environ['PATH'] += ':%s' % os.path.join(charm_dir, 'bin')
     venv = os.path.abspath('../.venv')
     vbin = os.path.join(venv, 'bin')
     vpip = os.path.join(vbin, 'pip')
@@ -42,7 +43,6 @@ def bootstrap_charm_deps():
         with open('/root/.pydistutils.cfg', 'w') as fp:
             # make sure that easy_install also only uses the wheelhouse
             # (see https://github.com/pypa/pip/issues/410)
-            charm_dir = os.environ['CHARM_DIR']
             fp.writelines([
                 "[easy_install]\n",
                 "allow_hosts = ''\n",
@@ -108,7 +108,7 @@ def activate_venv():
     This is handled automatically for normal hooks, but actions might
     need to invoke this manually, using something like:
 
-        # Load modules from $CHARM_DIR/lib
+        # Load modules from $JUJU_CHARM_DIR/lib
         import sys
         sys.path.append('lib')
 

--- a/lib/charms/layer/execd.py
+++ b/lib/charms/layer/execd.py
@@ -41,7 +41,7 @@ charm-pre-install and any other required resources. The charm-pre-install
 executables are run, and if successful, state saved so they will not be
 run again.
 
-    $CHARM_DIR/exec.d/mynamespace/charm-pre-install
+    $JUJU_CHARM_DIR/exec.d/mynamespace/charm-pre-install
 
 An alternative to branching a charm is to compose a new charm that contains
 the exec.d directory, using the original charm as a layer,
@@ -53,7 +53,7 @@ charmhelpers.core.hookenv.atstart().
 
 
 def default_execd_dir():
-    return os.path.join(os.environ['CHARM_DIR'], 'exec.d')
+    return os.path.join(os.environ['JUJU_CHARM_DIR'], 'exec.d')
 
 
 def execd_module_paths(execd_dir=None):


### PR DESCRIPTION
[CHARM_DIR is legacy](https://github.com/juju/juju/blob/staging/worker/uniter/runner/context/context.go#L572)

Discovered while trying to execute the collect-metrics hook in the reactive framework.
Related: https://github.com/CanonicalLtd/layer-metrics/issues/5