### PR TITLE
Change use_venv and include_system_packages default values

### DIFF
--- a/bin/layer-basic-wrapper
+++ b/bin/layer-basic-wrapper
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+find_charm_dirs() {
+    # try to guess the value for CHARM_DIR by looking for a non-subordinate
+    # charm directory; if there are several, pick the first by alpha order
+    if [[ -n "$JUJU_CHARM_DIR" ]]; then
+        if [[ -z "$CHARM_DIR" ]]; then
+            # set CHARM_DIR as well to help with backwards compatibility
+            export CHARM_DIR="$JUJU_CHARM_DIR"
+        fi
+        return
+    fi
+    agents_dir="/var/lib/juju/agents"
+    if [[ -d "$agents_dir" ]]; then
+        non_subordinates="$(grep -L 'subordinate:.*true' "$agents_dir"/*/charm/metadata.yaml | wc -l)"
+        if [[ "$non_subordinates" -gt 1 ]]; then
+            >&2 echo 'Ambiguous possibilities for JUJU_CHARM_DIR; please run within a Juju hook context'
+            exit 1
+        elif [[ "$non_subordinates" -eq 1 ]]; then
+            for unit_dir in $(/bin/ls -d "$agents_dir/unit-"*); do
+                if grep -q 'subordinate:.*true' "$unit_dir/charm/metadata.yaml"; then
+                    continue
+                fi
+                export JUJU_CHARM_DIR="$unit_dir/charm"
+                export CHARM_DIR="$JUJU_CHARM_DIR"
+                return
+            done
+        fi
+    fi
+    >&2 echo 'Unable to determine JUJU_CHARM_DIR; please run within a Juju hook context'
+    exit 1
+}
+
+try_activate_venv() {
+    if [[ -d "$JUJU_CHARM_DIR/../.venv" ]]; then
+        . "$JUJU_CHARM_DIR/../.venv/bin/activate"
+    fi
+}
+
+find_wrapped() {
+    PATH="${PATH/\/usr\/local\/sbin:}" which "$(basename "$0")"
+}
+
+
+find_charm_dirs
+try_activate_venv
+export PYTHONPATH="$JUJU_CHARM_DIR/lib:$PYTHONPATH"
+
+if [[ "$0" == "$BASH_SOURCE" ]]; then
+    # being invoked
+    exec "$(find_wrapped)" "$@"
+else
+    # being sourced
+    . "$(find_wrapped)"
+fi

--- a/bin/layer_option
+++ b/bin/layer_option
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
 import sys
-sys.path.append('lib')
-
 import argparse
 from charms.layer import options
 

--- a/layer.yaml
+++ b/layer.yaml
@@ -5,13 +5,13 @@ defines:
     description: Additional packages to be installed at time of bootstrap
   use_venv:
     type: boolean
-    default: false
+    default: true
     description: >
       Install charm dependencies (wheelhouse) into a Python virtual environment
       to help avoid conflicts with other charms or libraries on the machine.
   include_system_packages:
     type: boolean
-    default: false
+    default: true
     description: >
       If using a virtual environment, allow the venv to see Python packages
       installed at the system level.  This reduces isolation, but is necessary

--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -92,6 +92,22 @@ def bootstrap_charm_deps():
                 shutil.copy2('/usr/bin/pip.save', '/usr/bin/pip')
                 os.remove('/usr/bin/pip.save')
         os.remove('/root/.pydistutils.cfg')
+        # setup wrappers to ensure envs are used for scripts
+        shutil.copy2('bin/layer-basic-wrapper', '/usr/local/sbin/')
+        for wrapper in ('charms.reactive', 'charms.reactive.sh',
+                        'chlp', 'layer_option'):
+            src = os.path.join('/usr/local/sbin', 'layer-basic-wrapper')
+            dst = os.path.join('/usr/local/sbin', wrapper)
+            if not os.path.exists(dst):
+                os.symlink(src, dst)
+        if cfg.get('use_venv'):
+            shutil.copy2('bin/layer_option', vbin)
+        else:
+            shutil.copy2('bin/layer_option', '/usr/local/bin/')
+        # re-link the charm copy to the wrapper in case charms
+        # call bin/layer_option directly (as was the old pattern)
+        os.remove('bin/layer_option')
+        os.symlink('/usr/local/sbin/layer_option', 'bin/layer_option')
         # flag us as having already bootstrapped so we don't do it again
         open('wheelhouse/.bootstrapped', 'w').close()
         # Ensure that the newly bootstrapped libs are available.


### PR DESCRIPTION
Increase isolation for charms by default by switching to `use_venv: true` by default.  This should reduce confusion by novice and expert charmers alike by making it much less likely that charm dependencies, particularly versions of charmhelpers and charms.reactive, don't conflict and cause unexpected downgrades.

This also switches to `include_system_packages: true` by default as well so that the default venv doesn't block use of apt installed Python libs, though this should be rare anyway.

Finally, this also creates system-level wrappers for the CLI interfaces for this layer, charms.reactive, and charmhelpers which figure out and activate the correct venv or fall back to the system script if appropriate.

Fixes #104
Also fixes juju-solutions/charms.reactive#135