### PR TITLE
Allow layer-basic-wrapper to be used as shebang

### DIFF
--- a/bin/charm-env
+++ b/bin/charm-env
@@ -56,9 +56,12 @@ if [[ "$(basename "$0")" == "charm-env" ]]; then
     # being used as a shebang
     exec "$@"
 elif [[ "$0" == "$BASH_SOURCE" ]]; then
-    # being invoked
+    # being invoked as a symlink wrapping something to find in the venv
     exec "$(find_wrapped)" "$@"
+elif [[ "$(basename "$BASH_SOURCE")" == "charm-env" ]]; then
+    # being sourced directly; do nothing
+    /bin/true
 else
-    # being sourced
+    # being sourced for wrapped bash helpers
     . "$(find_wrapped)"
 fi

--- a/bin/charm-env
+++ b/bin/charm-env
@@ -52,7 +52,7 @@ find_charm_dirs
 try_activate_venv
 export PYTHONPATH="$JUJU_CHARM_DIR/lib:$PYTHONPATH"
 
-if [[ "$(basename "$0")" == "layer-basic-wrapper" ]]; then
+if [[ "$(basename "$0")" == "charm-env" ]]; then
     # being used as a shebang
     exec "$@"
 elif [[ "$0" == "$BASH_SOURCE" ]]; then

--- a/bin/layer-basic-wrapper
+++ b/bin/layer-basic-wrapper
@@ -52,7 +52,10 @@ find_charm_dirs
 try_activate_venv
 export PYTHONPATH="$JUJU_CHARM_DIR/lib:$PYTHONPATH"
 
-if [[ "$0" == "$BASH_SOURCE" ]]; then
+if [[ "$(basename "$0")" == "layer-basic-wrapper" ]]; then
+    # being used as a shebang
+    exec "$@"
+elif [[ "$0" == "$BASH_SOURCE" ]]; then
     # being invoked
     exec "$(find_wrapped)" "$@"
 else

--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -93,10 +93,10 @@ def bootstrap_charm_deps():
                 os.remove('/usr/bin/pip.save')
         os.remove('/root/.pydistutils.cfg')
         # setup wrappers to ensure envs are used for scripts
-        shutil.copy2('bin/layer-basic-wrapper', '/usr/local/sbin/')
+        shutil.copy2('bin/charm-env', '/usr/local/sbin/')
         for wrapper in ('charms.reactive', 'charms.reactive.sh',
                         'chlp', 'layer_option'):
-            src = os.path.join('/usr/local/sbin', 'layer-basic-wrapper')
+            src = os.path.join('/usr/local/sbin', 'charm-env')
             dst = os.path.join('/usr/local/sbin', wrapper)
             if not os.path.exists(dst):
                 os.symlink(src, dst)


### PR DESCRIPTION
To make activating venvs easier for actions and other charm scripts, layer-basic-wrapper can now be used as the shebang line, where it will ensure that the proper venv is activated and `$JUJU_CHARM_DIR/lib` added to your `PYTHONPATH`  prior to invoking your script.