### PR TITLE
ensure setuptools and setuptools_scm are latest

### DIFF
--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -82,6 +82,10 @@ def bootstrap_charm_deps():
         # https://github.com/pypa/pip/issues/56
         check_call([pip, 'install', '-U', '--no-index', '-f', 'wheelhouse',
                     'pip'])
+        # per https://github.com/juju-solutions/layer-basic/issues/110
+        # this replaces the setuptools that was copied over from the system on
+        # venv create with latest setuptools and adds setuptools_scm
+        check_call([pip, 'install', '-U', 'setuptools', 'setuptools_scm'])
         # install the rest of the wheelhouse deps
         check_call([pip, 'install', '-U', '--no-index', '-f', 'wheelhouse'] +
                    glob('wheelhouse/*'))

--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -85,7 +85,8 @@ def bootstrap_charm_deps():
         # per https://github.com/juju-solutions/layer-basic/issues/110
         # this replaces the setuptools that was copied over from the system on
         # venv create with latest setuptools and adds setuptools_scm
-        check_call([pip, 'install', '-U', 'setuptools', 'setuptools_scm'])
+        check_call([pip, 'install', '-U', '--no-index', '-f', 'wheelhouse',
+                    'setuptools', 'setuptools-scm'])
         # install the rest of the wheelhouse deps
         check_call([pip, 'install', '-U', '--no-index', '-f', 'wheelhouse'] +
                    glob('wheelhouse/*'))

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,3 +1,5 @@
 pip>=7.0.0,<8.2.0
+setuptools>24.3,<=39.0.1
+setuptools-scm<=1.17.0
 charmhelpers>=0.4.0,<1.0.0
 charms.reactive>=0.1.0,<2.0.0


### PR DESCRIPTION
We need to ensure that setuptools and setuptools_scm are
refreshed every now and again. This PR ensures we upgrade them
before installing anything else in the venv.

Fixes: https://github.com/juju-solutions/layer-basic/issues/110

Signed-off-by: jamesbeedy <jamesbeedy@gmail.com>