### PR TITLE
Import layer libs into charms.layer

### DIFF
--- a/lib/charms/layer/__init__.py
+++ b/lib/charms/layer/__init__.py
@@ -1,4 +1,6 @@
 import os
+from importlib import import_module
+from pathlib import Path
 
 
 class LayerOptions(dict):
@@ -19,3 +21,22 @@ def options(section=None, layer_file=None):
         layer_file = os.path.join(base_dir, 'layer.yaml')
 
     return LayerOptions(layer_file, section)
+
+
+def import_layer_libs():
+    """
+    Ensure that all layer libraries are imported.
+
+    This makes it possible to do the following:
+
+        from charms import layer
+
+        layer.foo.do_foo_thing()
+
+    Note: This function must be called after bootstrap.
+    """
+    for module_file in Path('lib/charms/layer').glob('*'):
+        module_name = module_file.stem
+        if module_name in ('__init__', 'basic', 'execd'):
+            continue
+        import_module('charms.layer.{}'.format(module_name))

--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -5,6 +5,7 @@ from glob import glob
 from subprocess import check_call, CalledProcessError
 from time import sleep
 
+from charms import layer
 from charms.layer.execd import execd_preinstall
 
 
@@ -142,12 +143,12 @@ def activate_venv():
     venv = os.path.abspath('../.venv')
     vbin = os.path.join(venv, 'bin')
     vpy = os.path.join(vbin, 'python')
-    from charms import layer
     cfg = layer.options('basic')
     if cfg.get('use_venv') and '.venv' not in sys.executable:
         # activate the venv
         os.environ['PATH'] = ':'.join([vbin, os.environ['PATH']])
         reload_interpreter(vpy)
+    layer.import_layer_libs()
 
 
 def reload_interpreter(python):


### PR DESCRIPTION
Premptively import all layer libs built into the charm into `charms.layer` so that they can be accessed via `charms.layer.foo` without explicitly importing them.

This is a proposal for creating a convention around layer lib imports.  I've been struggling with having a clean way to use a layer's lib from within that layer's reactive code, as well as in other layers or the charm layer, in a clean and consistent way.  Part of the issue is that the recommended convention for the names of both the layer lib file and reactive file are to match the layer name, which prevents conflicts across layers and makes it easy to tell what files come from what layers.  However, it can then be difficult in the layer's reactive file to reference the layer lib in a way that is clear what it is.

For a while, I was using `from charms.layer import foo as layer_lib` or (`as charm_lib`) but then that's not consistent with how it will be used in other layers, and not consistent with how other layers' libs are used in that layer.

This PR encourages the convention of always doing `from charms import layer` and then always referring to the lib of a layer as `layer.<layer_name>`.  For example, to use the `ensure_path` helper from the `snap` layer and the `is_leader` helper from the leadership layer in an action, you would use:

```python
#!/usr/local/sbin/charm-env python

from charms import layer

layer.snap.ensure_path()
if layer.leadership.is_leader():
    print('I am the leader')
```