### PR TITLE
Empty tests return error code 5, which is seen as an actual error.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,10 @@ envlist = py34, py35
 skip_missing_interpreters = True
 
 [testenv]
-commands = py.test -v
+# This is not pretty, but pytest will return 0 if all tests worked and 5 if no tests are found.
+# We want to consider no tests as an indication of success.
+commands = /bin/bash -c 'py.test -v || if [[ $? == 5 ]]; then true; fi'
+
 deps =
     -r{toxinidir}/requirements.txt
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skip_missing_interpreters = True
 [testenv]
 # This is not pretty, but pytest will return 0 if all tests worked and 5 if no tests are found.
 # We want to consider no tests as an indication of success.
-commands = /bin/bash -c 'py.test -v || if [[ $? == 5 ]]; then true; fi'
+commands = /bin/bash -c 'py.test -v || if [[ $? == 5 ]]; then true; else false; fi'
 
 deps =
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
In our case, we want no tests to mean there is simply nothing to test and that is ok.