### PR TITLE
Rebuild venv for post-series-upgrade hook

### DIFF
--- a/hooks/upgrade-charm
+++ b/hooks/upgrade-charm
@@ -1,17 +1,8 @@
 #!/usr/bin/env python3
 
 # Load modules from $JUJU_CHARM_DIR/lib
-import os
 import sys
 sys.path.append('lib')
-
-# This is an upgrade-charm context, make sure we install latest deps
-if not os.path.exists('wheelhouse/.upgrade'):
-    open('wheelhouse/.upgrade', 'w').close()
-    if os.path.exists('wheelhouse/.bootstrapped'):
-        os.unlink('wheelhouse/.bootstrapped')
-else:
-    os.unlink('wheelhouse/.upgrade')
 
 from charms.layer import basic
 basic.bootstrap_charm_deps()


### PR DESCRIPTION
After a series upgrade, the venv needs to be completely rebuilt to account for updates to the system's Python.  This PR also moves the logic for upgrade-charm wheelhouse updates out of the hook code so that
that logic is all in one spot and so we can drop the specialized hook code when the hook template improvements get into stable in the charm snap.