### PR TITLE
Make compatibility hack work for Python 3.4 (trusty)

### DIFF
--- a/lib/charms/layer/__init__.py
+++ b/lib/charms/layer/__init__.py
@@ -39,7 +39,14 @@ class OptionsBackwardsCompatibilityHack(sys.modules[__name__].__class__):
 
 def patch_options_interface():
     from charms.layer import options
-    options.__class__ = OptionsBackwardsCompatibilityHack
+    if sys.version_info.minor >= 5:
+        options.__class__ = OptionsBackwardsCompatibilityHack
+    else:
+        name = options.__name__
+        hack = OptionsBackwardsCompatibilityHack(name)
+        hack.get = options.get
+        sys.modules[name] = hack
+        sys.modules[__name__].options = hack
 
 
 try:

--- a/lib/charms/layer/__init__.py
+++ b/lib/charms/layer/__init__.py
@@ -42,6 +42,9 @@ def patch_options_interface():
     if sys.version_info.minor >= 5:
         options.__class__ = OptionsBackwardsCompatibilityHack
     else:
+        # Py 3.4 doesn't support changing the __class__, so we have to do it
+        # another way.  The last line is needed because we already have a
+        # reference that doesn't get updated with sys.modules.
         name = options.__name__
         hack = OptionsBackwardsCompatibilityHack(name)
         hack.get = options.get


### PR DESCRIPTION
The backwards compatibility hack from #116 doesn't work on trusty because it has Python 3.4.  This makes it work with 3.4 / trusty with even more hackery.

Depends on juju-solutions/layer-options#3 (merged)
Depends on juju-solutions/layer-status#4 (merged)
Fixes #117
Fixes juju-solutions/charms.reactive#185