### PR TITLE
Explicitly install python3-pip recommended packages

### DIFF
--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -54,6 +54,8 @@ def bootstrap_charm_deps():
             'python3-setuptools',
             'python3-yaml',
             'python3-dev',
+            'python3-wheel',
+            'build-essential',
         ])
         from charms.layer import options
         cfg = options.get('basic')


### PR DESCRIPTION
Installing the python3-pip package will normally also install the
build-essential and python3-wheel packages, because it recommends
them and a normal Juju provisioned machine uses the default Ubuntu
behavior. Many charms rely on these packages, so that the embedded
Python dependencies declared in wheelhouse.txt can be installed.

In some situations, the python3-pip recommended packages do not get
installed and charms fail. This occurs when site policy changes
apt behavior to not implicitly install recommended packages. It
may also occur when a subordinate charm is installed on a machine
where python3-pip has already been installed but its recommended
packages have not (although, in practice, this situation was likely
triggered by site policy).

In any case, it does not hurt to explicitly list packages that will
be implicitly installed. While this problem is potentially present
whenever packages are installed by the base layer, charm helpers or
the apt layer, explicitly adding build-essential and python3-wheel
will I think fix all the deployment failures due to this issue that
I have actually encountered.