### PR TITLE
Add python_packages layer option

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -3,7 +3,16 @@ defines:
   packages:
     type: array
     default: []
-    description: Additional packages to be installed at time of bootstrap
+    description: Additional packages to be installed at time of bootstrap.
+  python_packages:
+    type: array
+    default: []
+    description: >
+      Additional Python packages to be installed at time of bootstrap.
+      These should be in standard Python requirement form.  This is useful
+      if you have Python libraries that your charm code depends on but which
+      require compilation on the target architecture, and thus can't be
+      pre-packaged in the wheelhouse.
   use_venv:
     type: boolean
     default: true

--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -93,6 +93,9 @@ def bootstrap_charm_deps():
         # install the rest of the wheelhouse deps
         check_call([pip, 'install', '-U', '--no-index', '-f', 'wheelhouse'] +
                    glob('wheelhouse/*'))
+        # re-enable installation from pypi
+        os.remove('/root/.pydistutils.cfg')
+        # install python packages from layer options
         if cfg['python_packages']:
             check_call([pip, 'install', '-U'] + cfg['python_packages'])
         if not cfg.get('use_venv'):
@@ -101,7 +104,6 @@ def bootstrap_charm_deps():
             if os.path.exists('/usr/bin/pip.save'):
                 shutil.copy2('/usr/bin/pip.save', '/usr/bin/pip')
                 os.remove('/usr/bin/pip.save')
-        os.remove('/root/.pydistutils.cfg')
         # setup wrappers to ensure envs are used for scripts
         shutil.copy2('bin/charm-env', '/usr/local/sbin/')
         for wrapper in ('charms.reactive', 'charms.reactive.sh',

--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -93,6 +93,8 @@ def bootstrap_charm_deps():
         # install the rest of the wheelhouse deps
         check_call([pip, 'install', '-U', '--no-index', '-f', 'wheelhouse'] +
                    glob('wheelhouse/*'))
+        if cfg['python_packages']:
+            check_call([pip, 'install', '-U'] + cfg['python_packages'])
         if not cfg.get('use_venv'):
             # restore system pip to prevent `pip3 install -U pip`
             # from changing it


### PR DESCRIPTION
There are cases where Python packages require compilation on the target system architecture and thus can't be packaged in the wheelhouse.  This allows them to be installed as part of the normal bootstrap process so they don't need to be manually managed by the charm and do the right thing with regard to the venv.