### PR TITLE
Run apt update if bootstrap fails

### DIFF
--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -190,6 +190,12 @@ def apt_install(packages):
         except CalledProcessError:
             if attempt == 2:  # third attempt
                 raise
+            try:
+                # sometimes apt-get update needs to be run
+                check_call(['apt-get', 'update'])
+            except CalledProcessError:
+                # sometimes it's a dpkg lock issue
+                pass
             sleep(5)
         else:
             break


### PR DESCRIPTION
There seems to be some sort of image or race condition that causes bootstrap to fail on bionic due to missing packages.

Fixes #113