### PR TITLE
Enable by default charms.reactive flag and handler trace logging

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -26,3 +26,8 @@ defines:
       If using a virtual environment, allow the venv to see Python packages
       installed at the system level.  This reduces isolation, but is necessary
       to use Python packages installed via apt-get.
+  trace:
+    type: boolean
+    default: true
+    description: >
+      Enable DEBUG logging of charms.reactive flag changes and active handlers.

--- a/reactive/trace.py
+++ b/reactive/trace.py
@@ -1,0 +1,5 @@
+from charms import layer
+from charms.reactive import trace
+
+if layer.options.get('basic', 'trace'):
+    trace.install_tracer(trace.LogTracer())


### PR DESCRIPTION
This is one approach to turning on charms.reactive trace logging. I've enabled it by default, but that is certainly up for discussion. cs:postgresql stable is currently using this branch of layer:basic if anyone wants to see it live.

Alternative ideas:
 - a micro-layer, like layer:option that can be used to toggle trace logging on or off. This could be used by other non layer:basic base layers like layer-caas
 - Not having an option to toggle the logging, and just having charms.reactive turn it on.