### PR TITLE
Add feature to disable all charm code execution

### DIFF
--- a/bin/disable-charm
+++ b/bin/disable-charm
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+chlp unitdata set layer.basic.disable-charm true
+echo 'All charm code execution has been disabled in preparation for unit removal.'

--- a/hooks/hook.template
+++ b/hooks/hook.template
@@ -8,6 +8,15 @@ from charms.layer import basic  # noqa
 basic.bootstrap_charm_deps()
 
 from charmhelpers.core import hookenv  # noqa
+from charmhelpers.core import unitdata  # noqa
+
+# workaround https://bugs.launchpad.net/juju/+bug/1741506 by allowing all charm
+# code execution to be disabled to skip past any errors blocking removal
+if unitdata.kv().get('layer.basic.disable-charm', False):
+    hookenv.log('Charm has been disabled, skipping all charm code!',
+                level=hookenv.WARNING)
+    raise SystemExit(0)
+
 hookenv.atstart(basic.init_config_states)
 hookenv.atexit(basic.clear_config_states)
 

--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -125,15 +125,17 @@ def bootstrap_charm_deps():
         # setup wrappers to ensure envs are used for scripts
         shutil.copy2('bin/charm-env', '/usr/local/sbin/')
         for wrapper in ('charms.reactive', 'charms.reactive.sh',
-                        'chlp', 'layer_option'):
+                        'chlp', 'layer_option', 'disable-charm'):
             src = os.path.join('/usr/local/sbin', 'charm-env')
             dst = os.path.join('/usr/local/sbin', wrapper)
             if not os.path.exists(dst):
                 os.symlink(src, dst)
         if cfg.get('use_venv'):
             shutil.copy2('bin/layer_option', vbin)
+            shutil.copy2('bin/disable-charm', vbin)
         else:
             shutil.copy2('bin/layer_option', '/usr/local/bin/')
+            shutil.copy2('bin/disable-charm', '/usr/local/bin/')
         # re-link the charm copy to the wrapper in case charms
         # call bin/layer_option directly (as was the old pattern)
         os.remove('bin/layer_option')


### PR DESCRIPTION
As a workaround for https://bugs.launchpad.net/juju/+bug/1741506 this allows a charm author who needs to remove a unit which is in error state to disable further charm code execution to make it possible to (uncleanly) remove the unit despite any charm errors that are blocking it.  The command to disable the charm is:

```
juju run unit/0 -- disable-charm
```

This can then be followed up with resolving the last error and removing the unit:

```
juju resolved --no-retry unit/0
juju remove-unit unit/0
```

There's no way provided to re-enable, since this is intended as a last resort.