### PR TITLE
Fix config option access in the code.

### DIFF
--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -115,8 +115,8 @@ def bootstrap_charm_deps():
         # re-enable installation from pypi
         os.remove('/root/.pydistutils.cfg')
         # install python packages from layer options
-        if cfg['python_packages']:
-            check_call([pip, 'install', '-U'] + cfg['python_packages'])
+        if cfg.get('python_packages'):
+            check_call([pip, 'install', '-U'] + cfg.get('python_packages'))
         if not cfg.get('use_venv'):
             # restore system pip to prevent `pip3 install -U pip`
             # from changing it


### PR DESCRIPTION

The option 'python_packages' was being accessed with

`cfg['python_packages']
`
instead of with

`cfg.get('python_packages')
`
like every other option. It's irrelevant if the option exist on the config.yaml or not, just trying to access it this way will give a python error of non existing key.
