### PR TITLE
Add version to charm-env and prevent downgrades

### DIFF
--- a/bin/charm-env
+++ b/bin/charm-env
@@ -1,9 +1,7 @@
 #!/bin/bash
 
-if [[ "$1" == "--version" || "$1" == "-v" ]]; then
-    echo 1.1.0
-    exit 0
-fi
+VERSION="1.0.0"
+
 
 find_charm_dirs() {
     # Hopefully, $JUJU_CHARM_DIR is set so which venv to use in unambiguous.
@@ -73,6 +71,12 @@ try_activate_venv() {
 find_wrapped() {
     PATH="${PATH/\/usr\/local\/sbin:}" which "$(basename "$0")"
 }
+
+
+if [[ "$1" == "--version" || "$1" == "-v" ]]; then
+    echo "$VERSION"
+    exit 0
+fi
 
 
 # allow --charm option to hint which JUJU_CHARM_DIR to choose when ambiguous

--- a/bin/charm-env
+++ b/bin/charm-env
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ "$1" == "--version" || "$1" == "-v" ]]; then
+    echo 1.1.0
+    exit 0
+fi
+
 find_charm_dirs() {
     # Hopefully, $JUJU_CHARM_DIR is set so which venv to use in unambiguous.
     if [[ -n "$JUJU_CHARM_DIR" || -n "$CHARM_DIR" ]]; then


### PR DESCRIPTION
If two charms are co-located or subordinate with differing versions of the charm-env helper it can cause issues if the older version gets installed. This change adds a version number to the helper and logic
during the bootstrap to detect the installed version and upgrade it only if its own version is newer. It will also re-do the check for every hook, to handle the case where an older charm without this logic overwrites it after the fact.

Fixes #136