### PR TITLE
Install python3-pkg-resources on Trusty

### DIFF
--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -4,7 +4,6 @@ import shutil
 from glob import glob
 from subprocess import check_call, check_output, CalledProcessError
 from time import sleep
-from pkg_resources import parse_version
 
 from charms import layer
 from charms.layer.execd import execd_preinstall
@@ -153,6 +152,13 @@ def bootstrap_charm_deps():
 
 
 def install_or_update_charm_env():
+    # On Trusty python3-pkg-resources is not installed
+    try:
+        from pkg_resources import parse_version
+    except ImportError:
+        apt_install(['python3-pkg-resources'])
+        from pkg_resources import parse_version
+
     try:
         installed_version = parse_version(
             check_output(['/usr/local/sbin/charm-env',


### PR DESCRIPTION
On Trusty pkg_resources is not available as the python3 version of the
package is not installed by default.

Try the import and then install the python3-pkg-resources on import
failure.

Closes Issue: https://github.com/juju-solutions/layer-basic/issues/142