### PR TITLE
charm-env: Fix spurious import warning and not handling all subordinates properly

### DIFF
--- a/bin/charm-env
+++ b/bin/charm-env
@@ -25,7 +25,7 @@ find_charm_dirs() {
         found_charm_dir=""
         if [[ -n "$desired_charm" ]]; then
             for charm_dir in $(/bin/ls -d "$agents_dir"/unit-*/charm); do
-                charm_name="$(JUJU_CHARM_DIR="$charm_dir" charm-env python3 -c 'from charmhelpers.core.hookenv import charm_name; print(charm_name())')"
+                charm_name="$(grep -o '^['\''"]\?name['\''"]\?:.*' $charm_dir/metadata.yaml 2> /dev/null | sed -e 's/.*: *//' -e 's/['\''"]//g')"
                 if [[ "$charm_name" == "$desired_charm" ]]; then
                     if [[ -n "$found_charm_dir" ]]; then
                         >&2 echo "Ambiguous possibilities for JUJU_CHARM_DIR matching '$desired_charm'; please run within a Juju hook context"

--- a/bin/charm-env
+++ b/bin/charm-env
@@ -49,7 +49,7 @@ find_charm_dirs() {
             exit 1
         elif [[ "$non_subordinates" -eq 1 ]]; then
             for charm_dir in $(/bin/ls -d "$agents_dir"/unit-*/charm); do
-                if grep -q 'subordinate:.*true' "$charm_dir/metadata.yaml"; then
+                if grep -q 'subordinate"\?:.*true' "$charm_dir/metadata.yaml"; then
                     continue
                 fi
                 export JUJU_CHARM_DIR="$charm_dir"

--- a/bin/charm-env
+++ b/bin/charm-env
@@ -43,7 +43,7 @@ find_charm_dirs() {
             return
         fi
         # shellcheck disable=SC2126
-        non_subordinates="$(grep -L 'subordinate:.*true' "$agents_dir"/unit-*/charm/metadata.yaml | wc -l)"
+        non_subordinates="$(grep -L 'subordinate"\?:.*true' "$agents_dir"/unit-*/charm/metadata.yaml | wc -l)"
         if [[ "$non_subordinates" -gt 1 ]]; then
             >&2 echo 'Ambiguous possibilities for JUJU_CHARM_DIR; please use --charm or run within a Juju hook context'
             exit 1


### PR DESCRIPTION
There's a case where charm-env can create spurious warnings about failing to import charmhelpers when trying to determine the charm name for a given charm directory.  This avoids that by using `grep` and `sed` in place of trying to properly parse the yaml.

This also fixes an issue with subordinates that are built with `charm build` or otherwise use quotes around the `subordinate` field from being incorrectly identified as non-subordinate.  This should only affect interactive usage and should cut down on the "ambiguous possibilities" messages and be more DWYM.

Fixes #140