### PR TITLE
Fix deploy error due to new pip / old setuptools conflict

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,4 +1,4 @@
-pip>=18.1,<19.2
+pip>=18.1,<19.0
 setuptools<42
 setuptools-scm<=1.17.0
 charmhelpers>=0.4.0,<1.0.0

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,3 +1,6 @@
+# pip is pinned to <19.0 to avoid https://github.com/pypa/pip/issues/6164
+# even with installing setuptools before upgrading pip ends up with pip seeing
+# the older setuptools at the system level if include_system_packages is true
 pip>=18.1,<19.0
 setuptools<42
 setuptools-scm<=1.17.0


### PR DESCRIPTION
Newer versions of pip (>=19.0) don't work with older versions of setuptools (<40) due to an attribute error.  If `include_system_packages` is `false` (now the default), this is not an issue because of the newer setuptools that gets installed into the venv. However, when it's `true`, which is required for some charms, the install fails because pip somehow prefers the older system-installed setuptools over the newer one in the venv. Pinning pip avoids the problem until we can find a better solution.

See:
  * https://discourse.jujucharms.com/t/wheel-building-fails-during-charm-deployment/1947
  * https://github.com/pypa/pip/issues/6164