### PR TITLE
Fix issue 146

### DIFF
--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -113,8 +113,8 @@ def bootstrap_charm_deps():
         check_call([pip, 'install', '-U', '--no-index', '-f', 'wheelhouse',
                     'setuptools', 'setuptools-scm'])
         # install the rest of the wheelhouse deps
-        check_call([pip, 'install', '-U', '--ignore-installed', '--no-index', '-f', 'wheelhouse'] +
-                   glob('wheelhouse/*'))
+        check_call([pip, 'install', '-U', '--ignore-installed', '--no-index',
+                   '-f', 'wheelhouse'] + glob('wheelhouse/*'))
         # re-enable installation from pypi
         os.remove('/root/.pydistutils.cfg')
         # install python packages from layer options

--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -113,7 +113,7 @@ def bootstrap_charm_deps():
         check_call([pip, 'install', '-U', '--no-index', '-f', 'wheelhouse',
                     'setuptools', 'setuptools-scm'])
         # install the rest of the wheelhouse deps
-        check_call([pip, 'install', '-U', '--no-index', '-f', 'wheelhouse'] +
+        check_call([pip, 'install', '-U', '--ignore-installed', '--no-index', '-f', 'wheelhouse'] +
                    glob('wheelhouse/*'))
         # re-enable installation from pypi
         os.remove('/root/.pydistutils.cfg')


### PR DESCRIPTION
This patch fixes issue #146, where a charm that sets `use_venv: False`
breaks on install, by adding the `--ignore-installed` flag when
pip installing the wheelhouse deps