### PR TITLE
Fixed the support for centos and rhel

### DIFF
--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -9,6 +9,7 @@ from time import sleep
 from charms import layer
 from charms.layer.execd import execd_preinstall
 
+
 def get_series():
     """
     Return series for a few known OS:es.
@@ -34,8 +35,8 @@ def get_series():
     elif os.path.isfile('/etc/redhat-release'):
         with open('/etc/redhat-release', 'r') as redhatlsb:
             # CentOS Linux release 7.7.1908 (Core)
-            l = redhatlsb.readline()
-            release = int(l.split("release")[1].split()[0][0])
+            line = redhatlsb.readline()
+            release = int(line.split("release")[1].split()[0][0])
             series = "centos" + str(release)
 
     # Looking for content in /etc/lsb-release
@@ -81,7 +82,7 @@ def bootstrap_charm_deps():
     centos_packages = ['python3-pip',
                        'python3-setuptools',
                        'python3-devel',
-                       'python3-wheel' ]
+                       'python3-wheel']
 
     packages_needed = []
     if 'centos' in series:
@@ -178,8 +179,9 @@ def bootstrap_charm_deps():
         # re-enable installation from pypi
         os.remove('/root/.pydistutils.cfg')
 
-        # install pyyaml for centos7 altough this can be made through cloud-init
-        # Info : https://discourse.jujucharms.com/t/charms-for-centos-lets-begin/2339/8?u=erik-lonroth
+        # install pyyaml for centos7, since, unlike the ubuntu image, the
+        # default image for centos doesn't include pyyaml; see the discussion:
+        # https://discourse.jujucharms.com/t/charms-for-centos-lets-begin
         if 'centos' in series:
             check_call([pip, 'install', '-U', 'pyyaml'])
 
@@ -316,13 +318,14 @@ def apt_install(packages):
         else:
             break
 
+
 def yum_install(packages):
     """ Installs packages with yum.
         This function largely  mimics the apt_install function for consistency.
     """
     if packages:
         env = os.environ.copy()
-        cmd = ['yum','-y','install']
+        cmd = ['yum', '-y', 'install']
         for attempt in range(3):
             try:
                 check_call(cmd + packages, env=env)
@@ -338,6 +341,7 @@ def yum_install(packages):
                 break
     else:
         pass
+
 
 def init_config_states():
     import yaml

--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -146,7 +146,8 @@ def bootstrap_charm_deps():
         if cfg.get('use_venv'):
             if not os.path.exists(venv):
                 series = get_series()
-                if series in ('ubuntu12.04', 'precise', 'ubuntu14.04', 'trusty'):
+                if series in ('ubuntu12.04', 'precise',
+                              'ubuntu14.04', 'trusty'):
                     apt_install(['python-virtualenv'])
                 elif 'centos' in series:
                     yum_install(['python-virtualenv'])

--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -146,7 +146,7 @@ def bootstrap_charm_deps():
         if cfg.get('use_venv'):
             if not os.path.exists(venv):
                 series = get_series()
-                if series in ('precise', 'trusty'):
+                if series in ('ubuntu12.04', 'precise', 'ubuntu14.04', 'trusty'):
                     apt_install(['python-virtualenv'])
                 elif 'centos' in series:
                     yum_install(['python-virtualenv'])


### PR DESCRIPTION
This adds discovery of "centos6", "centos7" and "rhel" linux distributions that are using "yum" as package manager.

The juju layers: "basic" & "options", both fails on at least centos6 and centos7 which are both supported in MAAS clouds. This is needed by "SLURM" charms/bundles running HPC workloads - for example. This is also a huge stopper for a broader adoption of juju for "non ubuntu" OS:es.

See this thread: https://discourse.jujucharms.com/t/charms-for-centos-lets-begin/2339/16

This code is a prerequisite to be able to run reactive charms at all with OS:es using "yum".


## Additional patches depends on this
The charm-helpers package also need fixes to get "yum" like OS:es to run python reactive charms. 

As of today, in charm-helpers this code will fail:

`import yum`

This import will cause an error since "yum" its not available on most centos distros anymore and not in the default images of centos in MAAS. This patch removes that requirement and make centos deployments work with juju and python/reactive charms.

https://github.com/hallback/charm-helpers/tree/hallback/centosfixes