### PR TITLE
Pin setuptools_scm[toml]<3.4

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -3,6 +3,7 @@
 # the older setuptools at the system level if include_system_packages is true
 pip>=18.1,<19.0
 setuptools<42
+setuptools_scm[toml]<3.4
 setuptools-scm<=1.17.0
 charmhelpers>=0.4.0,<1.0.0
 charms.reactive>=0.1.0,<2.0.0


### PR DESCRIPTION
Since setuptools_scm[toml] 3.4 there is a hard dependency on setuptools>42
https://github.com/pypa/setuptools_scm#pyprojecttoml-usage

Closes #150