### PR TITLE
Pin Jinja2/PyYAML in wheelhouse.txt for Python 3.4

### DIFF
--- a/tests/bundles/minimal.yaml
+++ b/tests/bundles/minimal.yaml
@@ -11,7 +11,7 @@ applications:
     series: bionic
     charm: /tmp/charm-builds/minimal
     num_units: 1
-  minimal-disco:
-    series: disco
+  minimal-eoan:
+    series: eoan
     charm: /tmp/charm-builds/minimal
     num_units: 1

--- a/tests/charm-minimal/metadata.yaml
+++ b/tests/charm-minimal/metadata.yaml
@@ -8,4 +8,4 @@ series:
   - trusty
   - xenial
   - bionic
-  - disco
+  - eoan

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -2,6 +2,9 @@
 # even with installing setuptools before upgrading pip ends up with pip seeing
 # the older setuptools at the system level if include_system_packages is true
 pip>=18.1,<19.0
+# pin Jinja2 and PyYAML to the last versions supporting python 3.4 for trusty
+Jinja2<=2.10.1
+PyYAML<=5.2
 setuptools<42
 setuptools-scm<=1.17.0
 charmhelpers>=0.4.0,<1.0.0


### PR DESCRIPTION
The last versions of Jinja2 and PyYAML to support Python 3.4 are
2.10.1 and 5.2, respectively. In order to continue supporting
Ubuntu Trusty, which defaults to Python 3.4, the wheelhouse.txt
is updated to ensure newer versions aren't used.