### PR TITLE
Fix broken pip due to downgrade on Focal+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,21 +33,7 @@ script:
       sudo sh -c 'echo PATH=/snap/bin:$PATH >> /etc/environment';
       sudo lxd waitready;
       sudo lxd init --auto;
-      cat <<EOF> profile-update.yaml
-      config: {}
-      description: Default LXD profile - updated
-      devices:
-        eth0:
-          name: eth0
-          parent: lxdbr0
-          nictype: bridged
-          type: nic
-        root:
-          path: /
-          pool: default
-          type: disk
-      EOF
-      cat profile-update.yaml | sudo lxc profile edit default
+      cat .travis/profile-update.yaml | sudo lxc profile edit default
       sudo usermod -a -G lxd travis;
       sudo su - travis -c 'juju bootstrap --no-gui localhost';
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
       sudo sh -c 'echo PATH=/snap/bin:$PATH >> /etc/environment';
       sudo lxd waitready;
       sudo lxd init --auto;
-      cat .travis/profile-update.yaml | sudo lxc profile edit default
+      cat .travis/profile-update.yaml | sudo lxc profile edit default;
       sudo usermod -a -G lxd travis;
       sudo su - travis -c 'juju bootstrap --no-gui localhost';
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,5 +44,5 @@ script:
     fi
 after_failure:
   - if [ $ENV = 'func' ]; then
-      sudo su travis -c 'for application in trusty xenial bionic cosmic disco; do juju ssh -m $(juju models --format yaml|grep "^- name:.*zaza"|cut -f2 -d/) minimal-${application}/0 "sudo cat /var/log/juju/unit*.log";done';
+      sudo su travis -c 'for application in trusty xenial bionic eoan focal; do juju ssh -m $(juju models --format yaml|grep "^- name:.*zaza"|cut -f2 -d/) minimal-${application}/0 "sudo cat /var/log/juju/unit*.log";done';
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,21 @@ script:
       sudo sh -c 'echo PATH=/snap/bin:$PATH >> /etc/environment';
       sudo lxd waitready;
       sudo lxd init --auto;
+      cat <<EOF> profile-update.yaml
+      config: {}
+      description: Default LXD profile - updated
+      devices:
+        eth0:
+          name: eth0
+          parent: lxdbr0
+          nictype: bridged
+          type: nic
+        root:
+          path: /
+          pool: default
+          type: disk
+      EOF
+      cat profile-update.yaml | sudo lxc profile edit default
       sudo usermod -a -G lxd travis;
       sudo su - travis -c 'juju bootstrap --no-gui localhost';
     fi

--- a/.travis/profile-update.yaml
+++ b/.travis/profile-update.yaml
@@ -1,0 +1,12 @@
+config: {}
+description: Default LXD profile - updated
+devices:
+  eth0:
+    name: eth0
+    parent: lxdbr0
+    nictype: bridged
+    type: nic
+  root:
+    path: /
+    pool: default
+    type: disk

--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -237,7 +237,7 @@ def _load_wheelhouse_versions():
     for wheel in glob('wheelhouse/*'):
         pkg, ver = os.path.basename(wheel).split('-')
         # nb: LooseVersion ignores the file extension
-        versions[pkg] = LooseVersion(ver)
+        versions[pkg.replace('_', '-')] = LooseVersion(ver)
     return versions
 
 

--- a/tests/bundles/minimal.yaml
+++ b/tests/bundles/minimal.yaml
@@ -15,3 +15,7 @@ applications:
     series: eoan
     charm: /tmp/charm-builds/minimal
     num_units: 1
+  minimal-focal:
+    series: focal
+    charm: /tmp/charm-builds/minimal
+    num_units: 1

--- a/tests/charm-minimal/metadata.yaml
+++ b/tests/charm-minimal/metadata.yaml
@@ -9,3 +9,4 @@ series:
   - xenial
   - bionic
   - eoan
+  - focal

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -3,3 +3,6 @@ gate_bundles:
 - minimal
 tests:
 - zaza.charm_tests.noop.tests.NoopTest
+test_options:
+  force_deploy:
+    - minimal


### PR DESCRIPTION
Focal provides a newer version of pip (and setuptools) than what is bundled, and downgrading it in the venv leads to it being broken. This doesn't show until after the first bootstrap, so it fails on the first `upgrade-charm` hook rather than the `install` hook. This skips installing pip and setuptools if pip is already at a newer version in the venv.

Fixes #159