### PR TITLE
Use ``travis_wait`` to keep func test alive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,15 @@ matrix:
     - name: "Python 3.7"
       python: 3.7
       env: ENV=flake8,py3
+    - name: "Python 3.8"
+      python: 3.8
+      env: ENV=flake8,py3
     - name: "Functional test"
       env: ENV=func
 comment: |
   install dependencies in script phase saving time on simpler test environments
-  sudo back to ourself to activate lxd group membership executable search path
+  change permissions on lxd socket to allow travis user access
+  (^^ this is a throw-away CI environment, do not do this at home)
 script:
   - if [ $ENV = 'func' ]; then
       sudo apt update;
@@ -34,15 +38,14 @@ script:
       sudo lxd waitready;
       sudo lxd init --auto;
       cat .travis/profile-update.yaml | sudo lxc profile edit default;
-      sudo usermod -a -G lxd travis;
-      sudo su - travis -c 'juju bootstrap --no-gui localhost';
+      sudo chmod 666 /var/snap/lxd/common/lxd/unix.socket;
+      juju bootstrap --no-gui localhost;
     fi
-  - echo "export PATH=$PATH;cd $(pwd)" > $HOME/saved_path
-  - sudo su - travis -c "source $HOME/saved_path; tox -c tox.ini -e $ENV";
+  - travis_wait 50 tox -c tox.ini -e $ENV
   - if [ $ENV = 'func' ]; then
-      sudo su travis -c 'juju status -m $(juju models --format yaml|grep "^- name:.*zaza"|cut -f2 -d/)';
+      juju status -m $(juju models --format yaml|grep "^- name:.*zaza"|cut -f2 -d/);
     fi
 after_failure:
   - if [ $ENV = 'func' ]; then
-      sudo su travis -c 'for application in trusty xenial bionic eoan focal; do juju ssh -m $(juju models --format yaml|grep "^- name:.*zaza"|cut -f2 -d/) minimal-${application}/0 "sudo cat /var/log/juju/unit*.log";done';
+      for application in trusty xenial bionic eoan focal; do juju ssh -m $(juju models --format yaml|grep "^- name:.*zaza"|cut -f2 -d/) minimal-${application}/0 "sudo cat /var/log/juju/unit*.log";done;
     fi

--- a/tests/charm-minimal/layer.yaml
+++ b/tests/charm-minimal/layer.yaml
@@ -1,5 +1,5 @@
 includes: ['layer:basic']
 options:
   basic:
-    packages: ['libffi-dev', 'libssl-dev']
+    packages: ['libpq-dev']
 repo: https://github.com/juju-solutions/layer-basic.git

--- a/tests/charm-minimal/wheelhouse.txt
+++ b/tests/charm-minimal/wheelhouse.txt
@@ -1,1 +1,2 @@
-cryptography
+# We add a wheel that needs to be built from source to validate that this works
+psycopg2

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist = flake8, py35, py36, py37
+envlist = flake8, py3
 skip_missing_interpreters = True
 
 [testenv]
@@ -25,4 +25,4 @@ commands =
     /bin/mkdir -p /tmp/charm-builds/_tmp/layers
     /bin/bash -c '/bin/ln -sf $(readlink --canonicalize {toxinidir}) /tmp/charm-builds/_tmp/layers/layer-basic'
     charm-build tests/charm-minimal
-    functest-run-suite --log DEBUG --keep-model
+    functest-run-suite --keep-model


### PR DESCRIPTION
At present we have enabled excessive debug-logging to accompilsh
the same thing, but that makes it unpleasant to look at.

Change permissions on the LXD socket to give travis user access
instead of using the sudo back to ourself trick as it leads to
some unwanted complexity.

Add Python 3.8 target to test matrix.

Closes #161