### PR TITLE
Fix unversioned package update regression

### DIFF
--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -176,8 +176,8 @@ def bootstrap_charm_deps():
         # choose the best version in case there are multiple from layer
         # conflicts)
         pkgs = _load_wheelhouse_versions().keys() - set(pre_install_pkgs)
-        check_call([pip, 'install', '-U', '--ignore-installed', '--no-index',
-                   '-f', 'wheelhouse'] + list(pkgs))
+        check_call([pip, 'install', '-U', '--force-reinstall', '--no-index',
+                    '--no-cache-dir', '-f', 'wheelhouse'] + list(pkgs))
         # re-enable installation from pypi
         os.remove('/root/.pydistutils.cfg')
 


### PR DESCRIPTION
Prior to #160, we were passing filenames to pip for the wheelhouse install rather than package names. It seems that using filenames implicitly disables pip's caching of package archive files. After #160, since we are now using package names rather than file names (which does allow pip to handle dependency resolution better), the packages were getting copied out of the wheelhouse directory and into pip's cache dir on the initial install and not updated unless the filename changed (i.e., the version number changed).  Some of the OpenStack charms use a shared library directly from GitHub which doesn't bother tracking the library version, causing it to always have the same version.

Adding `--no-cache-dir` forces pip to always use the copy from the wheelhouse, even if it seems like it hasn't been changed, based on the file name.

This also switches from `--ignore-installed` to `--force-reinstall` because the latter is cleaner since the former can leave artifacts from previous package versions in the venv if they are removed from the newer package version.

Fixes #166