### PR TITLE
Remove allow_hosts workaround for Focal and after

### DIFF
--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -129,7 +129,6 @@ def bootstrap_charm_deps():
             # (see https://github.com/pypa/pip/issues/410)
             fp.writelines([
                 "[easy_install]\n",
-                "allow_hosts = ''\n",
                 "find_links = file://{}/wheelhouse/\n".format(charm_dir),
             ])
         if 'centos' in series:

--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -182,8 +182,12 @@ def bootstrap_charm_deps():
         pkgs = _load_wheelhouse_versions().keys() - set(pre_install_pkgs)
         check_call([pip, 'install', '-U', '--force-reinstall', '--no-index',
                     '--no-cache-dir', '-f', 'wheelhouse'] + list(pkgs))
-        # re-enable installation from pypi
-        os.remove('/root/.pydistutils.cfg')
+        if series in ('ubuntu12.04', 'precise',
+                      'ubuntu14.04', 'trusty',
+                      'ubuntu16.04', 'xenial',
+                      'ubuntu18.04', 'bionic'):
+            # re-enable installation from pypi
+            os.remove('/root/.pydistutils.cfg')
 
         # install pyyaml for centos7, since, unlike the ubuntu image, the
         # default image for centos doesn't include pyyaml; see the discussion:

--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -124,13 +124,18 @@ def bootstrap_charm_deps():
         open('wheelhouse/.upgrade', 'w').close()
     # bootstrap wheelhouse
     if os.path.exists('wheelhouse'):
-        with open('/root/.pydistutils.cfg', 'w') as fp:
-            # make sure that easy_install also only uses the wheelhouse
-            # (see https://github.com/pypa/pip/issues/410)
-            fp.writelines([
-                "[easy_install]\n",
-                "find_links = file://{}/wheelhouse/\n".format(charm_dir),
-            ])
+        if series in ('ubuntu12.04', 'precise',
+                      'ubuntu14.04', 'trusty',
+                      'ubuntu16.04', 'xenial',
+                      'ubuntu18.04', 'bionic'):
+            with open('/root/.pydistutils.cfg', 'w') as fp:
+                # make sure that easy_install also only uses the wheelhouse
+                # (see https://github.com/pypa/pip/issues/410)
+                fp.writelines([
+                    "[easy_install]\n",
+                    "allow_hosts = ''\n",
+                    "find_links = file://{}/wheelhouse/\n".format(charm_dir),
+                ])
         if 'centos' in series:
             yum_install(packages_needed)
         else:


### PR DESCRIPTION
The workaround for https://github.com/pypa/pip/issues/410 is no longer needed on newer Ubuntu releases and fails entirely now on Focal.

See discussion on #156, which this replaces with a slightly more conservative approach.

Fixes #149