### PR TITLE
Fix reinstall error with use_venv: false on bionic and earlier.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,13 +47,13 @@ script:
     fi
 after_failure:
   - if [ $ENV = 'func' ]; then
-      model=$(juju models --format yaml|grep "^- name:.*zaza"|cut -f2 -d/)
+      model=$(juju models --format yaml|grep "^- name:.*zaza"|cut -f2 -d/);
       for application in trusty xenial bionic eoan focal; do
         if juju status -m $model minimal-${application} | grep -q error; then
-          juju ssh -m $model minimal-${application}/0 "sudo cat /var/log/juju/unit*.log"
-        fi
+          juju ssh -m $model minimal-${application}/0 "sudo cat /var/log/juju/unit*.log";
+        fi;
         if juju status -m $model minimal-no-venv-${application} | grep -q error; then
-          juju ssh -m $model minimal-no-venv-${application}/0 "sudo cat /var/log/juju/unit*.log"
-        fi
+          juju ssh -m $model minimal-no-venv-${application}/0 "sudo cat /var/log/juju/unit*.log";
+        fi;
       done;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,5 +47,13 @@ script:
     fi
 after_failure:
   - if [ $ENV = 'func' ]; then
-      for application in trusty xenial bionic eoan focal; do juju ssh -m $(juju models --format yaml|grep "^- name:.*zaza"|cut -f2 -d/) minimal-${application}/0 "sudo cat /var/log/juju/unit*.log";done;
+      model=$(juju models --format yaml|grep "^- name:.*zaza"|cut -f2 -d/)
+      for application in trusty xenial bionic eoan focal; do
+        if juju status -m $model minimal-${application} | grep -q error; then
+          juju ssh -m $model minimal-${application}/0 "sudo cat /var/log/juju/unit*.log"
+        fi
+        if juju status -m $model minimal-no-venv-${application} | grep -q error; then
+          juju ssh -m $model minimal-no-venv-${application}/0 "sudo cat /var/log/juju/unit*.log"
+        fi
+      done;
     fi

--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -180,12 +180,16 @@ def bootstrap_charm_deps():
         # choose the best version in case there are multiple from layer
         # conflicts)
         pkgs = _load_wheelhouse_versions().keys() - set(pre_install_pkgs)
-        check_call([pip, 'install', '-U', '--force-reinstall', '--no-index',
+        reinstall_flag = '--force-reinstall'
+        pre_eoan = series in ('ubuntu12.04', 'precise',
+                              'ubuntu14.04', 'trusty',
+                              'ubuntu16.04', 'xenial',
+                              'ubuntu18.04', 'bionic')
+        if not cfg.get('use_venv', True) and pre_eoan:
+            reinstall_flag = '--ignore-installed'
+        check_call([pip, 'install', '-U', reinstall_flag, '--no-index',
                     '--no-cache-dir', '-f', 'wheelhouse'] + list(pkgs))
-        if series in ('ubuntu12.04', 'precise',
-                      'ubuntu14.04', 'trusty',
-                      'ubuntu16.04', 'xenial',
-                      'ubuntu18.04', 'bionic'):
+        if pre_eoan:
             # re-enable installation from pypi
             os.remove('/root/.pydistutils.cfg')
 

--- a/tests/bundles/minimal.yaml
+++ b/tests/bundles/minimal.yaml
@@ -19,3 +19,23 @@ applications:
     series: focal
     charm: /tmp/charm-builds/minimal
     num_units: 1
+  minimal-no-venv-trusty:
+    series: trusty
+    charm: /tmp/charm-builds/minimal-no-venv
+    num_units: 1
+  minimal-no-venv-xenial:
+    series: xenial
+    charm: /tmp/charm-builds/minimal-no-venv
+    num_units: 1
+  minimal-no-venv-bionic:
+    series: bionic
+    charm: /tmp/charm-builds/minimal-no-venv
+    num_units: 1
+  minimal-no-venv-eoan:
+    series: eoan
+    charm: /tmp/charm-builds/minimal-no-venv
+    num_units: 1
+  minimal-no-venv-focal:
+    series: focal
+    charm: /tmp/charm-builds/minimal-no-venv
+    num_units: 1

--- a/tests/charm-minimal-no-venv/layer.yaml
+++ b/tests/charm-minimal-no-venv/layer.yaml
@@ -1,0 +1,4 @@
+includes: [layer:charm-minimal]
+options:
+  basic:
+    use_venv: false

--- a/tests/charm-minimal-no-venv/metadata.yaml
+++ b/tests/charm-minimal-no-venv/metadata.yaml
@@ -1,0 +1,12 @@
+name: minimal-no-venv
+summary: minimal charm used to functionally test layer-basic
+description: reactive charm with some tricky deps to test venv bootstrapping
+maintainer: Juju Developers <juju@lists.ubuntu.com>
+tags:
+  - CI
+series:
+  - trusty
+  - xenial
+  - bionic
+  - eoan
+  - focal

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,10 @@ setenv = CHARM_LAYERS_DIR=/tmp/charm-builds/_tmp/layers
 passenv = HOME
 commands =
     /bin/rm -rf /tmp/charm-builds/_tmp /tmp/charm-builds/minimal
+    /bin/rm -rf /tmp/charm-builds/_tmp /tmp/charm-builds/minimal-no-venv
     /bin/mkdir -p /tmp/charm-builds/_tmp/layers
     /bin/bash -c '/bin/ln -sf $(readlink --canonicalize {toxinidir}) /tmp/charm-builds/_tmp/layers/layer-basic'
+    /bin/bash -c '/bin/ln -sf $(readlink --canonicalize {toxinidir}/tests/charm-minimal) /tmp/charm-builds/_tmp/layers/charm-minimal'
     charm-build tests/charm-minimal
+    charm-build tests/charm-minimal-no-venv
     functest-run-suite --keep-model

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     -r{toxinidir}/requirements.txt
 
 [testenv:flake8]
-commands = flake8
+commands = flake8 --ignore E741 reactive lib tests unit_tests
 
 [testenv:func]
 basepython = python3


### PR DESCRIPTION
The change in #167 to use `--force-reinstall`, while significantly safer overall does fail on bionic and earlier when using `use_venv: false`. This was missed in the existing functional tests, so this first adds tests to cover that and ensure that things like this will be caught going forward, then adds a fix to use `--force-reinstall` when possible but otherwise fall back to the previous `--ignore-installed` behavior.

Fixes #168