### PR TITLE
Add LANG=C.UTF-8 if it isn't set for subprocesses

### DIFF
--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -11,6 +11,12 @@ from charms import layer
 from charms.layer.execd import execd_preinstall
 
 
+def _get_subprocess_env():
+    env = os.environ.copy()
+    env['LANG'] = env.get('LANG', 'C.UTF-8')
+    return env
+
+
 def get_series():
     """
     Return series for a few known OS:es.
@@ -163,7 +169,7 @@ def bootstrap_charm_deps():
                 cmd = ['virtualenv', '-ppython3', '--never-download', venv]
                 if cfg.get('include_system_packages'):
                     cmd.append('--system-site-packages')
-                check_call(cmd)
+                check_call(cmd, env=_get_subprocess_env())
             os.environ['PATH'] = ':'.join([vbin, os.environ['PATH']])
             pip = vpip
         else:
@@ -186,7 +192,8 @@ def bootstrap_charm_deps():
         if not cfg.get('use_venv', True) and pre_eoan:
             reinstall_flag = '--ignore-installed'
         check_call([pip, 'install', '-U', reinstall_flag, '--no-index',
-                    '--no-cache-dir', '-f', 'wheelhouse'] + list(pkgs))
+                    '--no-cache-dir', '-f', 'wheelhouse'] + list(pkgs),
+                   env=_get_subprocess_env())
         # re-enable installation from pypi
         os.remove('/root/.pydistutils.cfg')
 
@@ -194,11 +201,13 @@ def bootstrap_charm_deps():
         # default image for centos doesn't include pyyaml; see the discussion:
         # https://discourse.jujucharms.com/t/charms-for-centos-lets-begin
         if 'centos' in series:
-            check_call([pip, 'install', '-U', 'pyyaml'])
+            check_call([pip, 'install', '-U', 'pyyaml'],
+                       env=_get_subprocess_env())
 
         # install python packages from layer options
         if cfg.get('python_packages'):
-            check_call([pip, 'install', '-U'] + cfg.get('python_packages'))
+            check_call([pip, 'install', '-U'] + cfg.get('python_packages'),
+                       env=_get_subprocess_env())
         if not cfg.get('use_venv'):
             # restore system pip to prevent `pip3 install -U pip`
             # from changing it
@@ -254,7 +263,7 @@ def _update_if_newer(pip, pkgs):
     for pkg in pkgs:
         if pkg not in installed or wheelhouse[pkg] > installed[pkg]:
             check_call([pip, 'install', '-U', '--no-index', '-f', 'wheelhouse',
-                        pkg])
+                        pkg], env=_get_subprocess_env())
 
 
 def install_or_update_charm_env():
@@ -331,7 +340,7 @@ def apt_install(packages):
     if isinstance(packages, (str, bytes)):
         packages = [packages]
 
-    env = os.environ.copy()
+    env = _get_subprocess_env()
 
     if 'DEBIAN_FRONTEND' not in env:
         env['DEBIAN_FRONTEND'] = 'noninteractive'
@@ -348,7 +357,7 @@ def apt_install(packages):
                 raise
             try:
                 # sometimes apt-get update needs to be run
-                check_call(['apt-get', 'update'])
+                check_call(['apt-get', 'update'], env=env)
             except CalledProcessError:
                 # sometimes it's a dpkg lock issue
                 pass
@@ -371,7 +380,7 @@ def yum_install(packages):
                 if attempt == 2:
                     raise
                 try:
-                    check_call(['yum', 'update'])
+                    check_call(['yum', 'update'], env=env)
                 except CalledProcessError:
                     pass
                 sleep(5)

--- a/unit_tests/test_lib_charms_layer_basic.py
+++ b/unit_tests/test_lib_charms_layer_basic.py
@@ -1,8 +1,11 @@
+import os
 import mock
 
 import lib.charms.layer.basic as basic
 
 import unit_tests.utils as test_utils
+
+from unittest.mock import patch
 
 
 class TestLayerBasic(test_utils.BaseTestCase):
@@ -26,3 +29,19 @@ class TestLayerBasic(test_utils.BaseTestCase):
             mock.call('2.8.1.tar.gz'),
             mock.call('1.17.0.tar.gz'),
         ], any_order=True)
+
+    @patch.dict('os.environ', {'LANG': 'su_SU.UTF-8'})
+    def test__get_subprocess_env_lang_set(self):
+        env = basic._get_subprocess_env()
+        self.assertEqual(env['LANG'], 'su_SU.UTF-8')
+        self.assertEqual(dict(os.environ), env)
+
+    def test__get_subprocess_env_lang_not_set(self):
+        with mock.patch.dict('os.environ'):
+            del os.environ['LANG']
+            env = basic._get_subprocess_env()
+            self.assertEqual(env['LANG'], 'C.UTF-8')
+            # The only difference between dicts is the lack of LANG
+            # in os.environ.
+            self.assertEqual({key for key in set(env) - set(os.environ)},
+                             {'LANG'})


### PR DESCRIPTION
LANG is used to determine the default decoder when reading files in
Python. If it isn't set, some python versions simply default to ASCII
which leads to errors in some cases during Python package installation.

Juju did not set LANG in hook environments until 2.7 where it started to
add LANG=C.UTF-8. In order to support pre-2.7 environments where the
presence of LANG is significant during the package installation and
upgrades, let's add LANG explicitly if it is not set.

Fixes: #173