### PR TITLE
Pin netaddr

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -10,3 +10,5 @@ setuptools-scm<=1.17.0
 charmhelpers>=0.4.0,<1.0.0
 charms.reactive>=0.1.0,<2.0.0
 wheel<0.34
+# pin netaddr to avoid pulling importlib-resources
+netaddr<=0.7.19


### PR DESCRIPTION
netaddr 0.7.20 pulls in importlib-resources, which depends on a newer
version of setuptools_scm than we use.  It also pulls zipp, which
depends on a newer version of setuptools than we use.  Pinning to
0.7.19 avoids this.