### PR TITLE
Improve check for including allow_hosts

### DIFF
--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -147,7 +147,9 @@ def bootstrap_charm_deps():
             "[easy_install]\n",
             "find_links = file://{}/wheelhouse/\n".format(charm_dir),
         ]
-        if pre_eoan:
+        setuptools_ver = _load_installed_versions('pip3').get('setuptools')
+        max_allow_hosts_ver = LooseVersion('42.0.0')
+        if not setuptools_ver or setuptools_ver < max_allow_hosts_ver:
             pydistutils_lines.append("allow_hosts = ''\n")
         with open('/root/.pydistutils.cfg', 'w') as fp:
             # make sure that easy_install also only uses the wheelhouse

--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -143,6 +143,17 @@ def bootstrap_charm_deps():
                               'ubuntu14.04', 'trusty',
                               'ubuntu16.04', 'xenial',
                               'ubuntu18.04', 'bionic')
+        if 'centos' in series:
+            yum_install(packages_needed)
+        else:
+            apt_install(packages_needed)
+        from charms.layer import options
+        cfg = options.get('basic')
+        # include packages defined in layer.yaml
+        if 'centos' in series:
+            yum_install(cfg.get('packages', []))
+        else:
+            apt_install(cfg.get('packages', []))
         pydistutils_lines = [
             "[easy_install]\n",
             "find_links = file://{}/wheelhouse/\n".format(charm_dir),
@@ -155,17 +166,6 @@ def bootstrap_charm_deps():
             # make sure that easy_install also only uses the wheelhouse
             # (see https://github.com/pypa/pip/issues/410)
             fp.writelines(pydistutils_lines)
-        if 'centos' in series:
-            yum_install(packages_needed)
-        else:
-            apt_install(packages_needed)
-        from charms.layer import options
-        cfg = options.get('basic')
-        # include packages defined in layer.yaml
-        if 'centos' in series:
-            yum_install(cfg.get('packages', []))
-        else:
-            apt_install(cfg.get('packages', []))
         # if we're using a venv, set it up
         if cfg.get('use_venv'):
             if not os.path.exists(venv):


### PR DESCRIPTION
Using the series as a proxy to determine if allow_hosts is supported is not rigorous, so this makes it check the setuptools version directly.

Fixes https://bugs.launchpad.net/charm-octavia/+bug/1884164