### PR TITLE
Stop pip3 AND easy_install from accessing network on install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ script:
       sudo apt update;
       sudo apt install -y distro-info;
       sudo apt remove -y --purge lxd lxd-client;
+      sudo snap install core;
       sudo snap install lxd;
       sudo snap install juju --classic;
       sudo snap install charm --classic;

--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -146,6 +146,8 @@ def bootstrap_charm_deps():
         pydistutils_lines = [
             "[easy_install]\n",
             "find_links = file://{}/wheelhouse/\n".format(charm_dir),
+            "no_index=True\n",
+            "index_url=\n",   # deliberately nothing here; disables it.
         ]
         if pre_eoan:
             pydistutils_lines.append("allow_hosts = ''\n")


### PR DESCRIPTION
This change prevents the wheelhouse installation from accessing the
network at all.  This allows it to install quickly behind firewalls that
silently drop packets causing long delays in installing the packages if
a dependency is 'later' in the wheelhouse install, which is done in
directory order (usually alphabetically).

Closes launchpad bug: #1884449