### PR TITLE
Remove Eoan from functional tests

### DIFF
--- a/tests/bundles/minimal.yaml
+++ b/tests/bundles/minimal.yaml
@@ -11,10 +11,6 @@ applications:
     series: bionic
     charm: /tmp/charm-builds/minimal
     num_units: 1
-  minimal-eoan:
-    series: eoan
-    charm: /tmp/charm-builds/minimal
-    num_units: 1
   minimal-focal:
     series: focal
     charm: /tmp/charm-builds/minimal
@@ -29,10 +25,6 @@ applications:
     num_units: 1
   minimal-no-venv-bionic:
     series: bionic
-    charm: /tmp/charm-builds/minimal-no-venv
-    num_units: 1
-  minimal-no-venv-eoan:
-    series: eoan
     charm: /tmp/charm-builds/minimal-no-venv
     num_units: 1
   minimal-no-venv-focal:


### PR DESCRIPTION
Eoan has been EOLed and no longer has images available, so it gets stuck in pending and causes the functional tests to hang.