### PR TITLE
Fix incompatible usage of Requirement

### DIFF
--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -256,12 +256,12 @@ def _load_installed_versions(pip):
     versions = {}
     for pkg_ver in pip_freeze.splitlines():
         try:
-            req = Requirement(pkg_ver)
+            req = Requirement.parse(pkg_ver)
         except ValueError:
             continue
         versions.update({
-            req.name: LooseVersion(_.version)
-            for _ in req.specifier if _.operator == '=='
+            req.project_name: LooseVersion(ver)
+            for op, ver in req.specs if op == '=='
         })
     return versions
 


### PR DESCRIPTION
The change in #182 used undocumented methods / attributes of the Requirement class which worked on newer releases of setuptools but not on the one available in trusty, leading to functional test failures.