### PR TITLE
Clear the venv on all upgrades

### DIFF
--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -130,8 +130,8 @@ def bootstrap_charm_deps():
             is_broken_venv = True
         else:
             is_broken_venv = False
-        if is_series_upgrade or is_broken_venv:
-            # series upgrade should do a full clear of the venv, rather than
+        if is_upgrade or is_broken_venv:
+            # All upgrades should do a full clear of the venv, rather than
             # just updating it, to bring in updates to Python itself
             shutil.rmtree(venv)
     if is_upgrade:


### PR DESCRIPTION
Major upgrades of setuptools SCM break with pre-existing versions [0].

Remove the venv on charm upgrades to avoid this and other potential problems.

Tested with Octavia.

Closes-Bug: #1891639 [1]

[0] https://github.com/fink/fink-distributions/issues/219
[1] https://bugs.launchpad.net/charm-octavia/+bug/1891639