### PR TITLE
Fix upgrade flag file created too early

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     -r{toxinidir}/requirements.txt
 
 [testenv:flake8]
-commands = flake8 --ignore E741 reactive lib tests unit_tests
+commands = flake8 reactive lib tests unit_tests
 
 [testenv:func]
 basepython = python3
@@ -27,3 +27,9 @@ commands =
     charm-build tests/charm-minimal
     charm-build tests/charm-minimal-no-venv
     functest-run-suite --keep-model
+
+
+[flake8]
+ignore =
+    E741,  # ambiguous variable name
+    W504   # line break after binary operator (have to ignore either this or W503)


### PR DESCRIPTION
During an upgrade a flag file is created at `wheelhouse/.upgrade` to indicate that a charm upgrade has been started so that when the interpreter is reloaded after updating the venv, it doesn't get stuck in a loop repeatedly doing the upgrade.  However, this flag file is created before the upgrade is successfully completed, so a failed upgrade can leave the flag file around and make the charm think the upgrade already happened, even though it actually failed. This can leave the charm in a state where it cannot retry the upgrade and is stuck in a broken state.

Fixes #189