### PR TITLE
Pin MarkupSafe < 2.0.0 for py35 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,10 +39,12 @@ jobs:
       - name: Run test
         run: tox -e func
       - name: Show Status
+        if: ${{ always() }}
         run: |
           model=$(juju models --format yaml|grep "^- name:.*zaza"|cut -f2 -d/);
           juju status -m "$model"
       - name: Show Error Logs
+        if: ${{ always() }}
         run: |
           model=$(juju models --format yaml|grep "^- name:.*zaza"|cut -f2 -d/);
           juju debug-log -m "$model" --replay --no-tail --level ERROR

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -2,9 +2,11 @@
 # even with installing setuptools before upgrading pip ends up with pip seeing
 # the older setuptools at the system level if include_system_packages is true
 pip>=18.1,<19.0
-# pin Jinja2 and PyYAML to the last versions supporting python 3.4 for trusty
+# pin Jinja2, PyYAML and MarkupSafe to the last versions supporting python 3.5
+# for trusty
 Jinja2<=2.10.1
 PyYAML<=5.2
+MarkupSafe<2.0.0
 setuptools<42
 setuptools-scm<=1.17.0
 charmhelpers>=0.4.0,<1.0.0


### PR DESCRIPTION
MarkupSafe 2.0.0+ (required for Jinja2) removed py35 compatability, so
we need to pin it for charms to work on xenial.

Closes-bug: #196