### PR TITLE
Tweak dependency versions for newer Pythons

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           pip install tox
       - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@master
+        uses: charmed-kubernetes/actions-operator@main
       - name: Run test
         run: tox -e func
       - name: Show Status

--- a/README.md
+++ b/README.md
@@ -12,5 +12,19 @@ Go read the [layer-basic documentation][] for more info on how to use this
 layer. It is now hosted together with the charms.reactive documentation in order
 to reduce the amount of places a charmer needs to search for info.
 
+# Python Versions, Built charms and what they can run on.
+
+Due to major backwards incompatibilities between Python 3.10 and previous
+versions, there is a compatibility break between Python 3.8 (focal) and earlier
+versions of Python.  Why Python 3.8 rather than 3.10?  Mostly due to all of the
+incompatibilities being deprecated and available in Python 3.8, so the ability
+of authors to test at that version.
+
+As the charmhub.io now offers a place to build reactive charms on a per series
+('base') and architecture basis, layer-basic supports *at least* Python 3.5 to
+Python 3.10.  However, a charm *built* on Python 3.5 won't work on Python 3.8
+and vice-versa.  The objective going forwards is to build the charm for the
+*base* that the charm will run on.
+
 [charm-helpers]: https://pythonhosted.org/charmhelpers/
 [layer-basic documentation]: https://charmsreactive.readthedocs.io/en/latest/layer-basic.html

--- a/lib/charms/layer/basic.py
+++ b/lib/charms/layer/basic.py
@@ -218,7 +218,6 @@ def bootstrap_charm_deps():
                 reinstall_flag = '--ignore-installed'
             check_call([pip, 'install', '-U', reinstall_flag, '--no-index',
                         '--no-cache-dir', '-f', 'wheelhouse'] + list(pkgs),
-                        # '-f', 'wheelhouse'] + list(pkgs),
                        env=_get_subprocess_env())
         # re-enable installation from pypi
         os.remove('/root/.pydistutils.cfg')

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
-charm-tools
+# Use latest so that layer-basic tests against main branch
+git+https://github.com/juju/charm-tools.git#egg=charmtools
 git+https://github.com/openstack-charmers/zaza.git#egg=zaza

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 # Use latest so that layer-basic tests against main branch
-git+https://github.com/juju/charm-tools.git#egg=charmtools
+git+https://github.com/juju/charm-tools.git#egg=charm-tools
 git+https://github.com/openstack-charmers/zaza.git#egg=zaza

--- a/tests/bundles/minimal.yaml
+++ b/tests/bundles/minimal.yaml
@@ -1,32 +1,32 @@
 applications:
-  minimal-trusty:
-    series: trusty
-    charm: /tmp/charm-builds/minimal
-    num_units: 1
-  minimal-xenial:
-    series: xenial
-    charm: /tmp/charm-builds/minimal
-    num_units: 1
-  minimal-bionic:
-    series: bionic
-    charm: /tmp/charm-builds/minimal
-    num_units: 1
+  #minimal-trusty:
+    #series: trusty
+    #charm: /tmp/charm-builds/minimal
+    #num_units: 1
+  #minimal-xenial:
+    #series: xenial
+    #charm: /tmp/charm-builds/minimal
+    #num_units: 1
+  #minimal-bionic:
+    #series: bionic
+    #charm: /tmp/charm-builds/minimal
+    #num_units: 1
   minimal-focal:
     series: focal
     charm: /tmp/charm-builds/minimal
     num_units: 1
-  minimal-no-venv-trusty:
-    series: trusty
-    charm: /tmp/charm-builds/minimal-no-venv
-    num_units: 1
-  minimal-no-venv-xenial:
-    series: xenial
-    charm: /tmp/charm-builds/minimal-no-venv
-    num_units: 1
-  minimal-no-venv-bionic:
-    series: bionic
-    charm: /tmp/charm-builds/minimal-no-venv
-    num_units: 1
+  #minimal-no-venv-trusty:
+    #series: trusty
+    #charm: /tmp/charm-builds/minimal-no-venv
+    #num_units: 1
+  #minimal-no-venv-xenial:
+    #series: xenial
+    #charm: /tmp/charm-builds/minimal-no-venv
+    #num_units: 1
+  #minimal-no-venv-bionic:
+    #series: bionic
+    #charm: /tmp/charm-builds/minimal-no-venv
+    #num_units: 1
   minimal-no-venv-focal:
     series: focal
     charm: /tmp/charm-builds/minimal-no-venv

--- a/tests/bundles/minimal.yaml
+++ b/tests/bundles/minimal.yaml
@@ -1,3 +1,5 @@
+# Disable all bundles that aren't 'latest', currently focal
+# See readme for details
 applications:
   #minimal-trusty:
     #series: trusty

--- a/tests/charm-minimal/wheelhouse.txt
+++ b/tests/charm-minimal/wheelhouse.txt
@@ -1,2 +1,3 @@
 # We add a wheel that needs to be built from source to validate that this works
-psycopg2
+psycopg2;python_version < '3.8'
+psycopg;python_version >= '3.8'

--- a/tox.ini
+++ b/tox.ini
@@ -24,8 +24,8 @@ commands =
     /bin/mkdir -p /tmp/charm-builds/_tmp/layers
     /bin/bash -c '/bin/ln -sf $(readlink --canonicalize {toxinidir}) /tmp/charm-builds/_tmp/layers/layer-basic'
     /bin/bash -c '/bin/ln -sf $(readlink --canonicalize {toxinidir}/tests/charm-minimal) /tmp/charm-builds/_tmp/layers/charm-minimal'
-    charm-build tests/charm-minimal
-    charm-build tests/charm-minimal-no-venv
+    charm-build --log-level DEBUG tests/charm-minimal
+    charm-build --log-level DEBUG tests/charm-minimal-no-venv
     functest-run-suite --keep-model
 
 

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -4,9 +4,16 @@
 pip>=18.1,<19.0
 # pin Jinja2, PyYAML and MarkupSafe to the last versions supporting python 3.5
 # for trusty
-Jinja2<=2.10.1
-PyYAML<=5.2
-MarkupSafe<2.0.0
+Jinja2==2.10;python_version >= '3.0' and python_version <= '3.4' # py3 trusty
+Jinja2==2.11;python_version == '2.7' or python_version == '3.5'  # py27, py35
+Jinja2;python_version >= '3.6' # py36 and on
+
+PyYAML==5.2;python_version >= '3.0' and python_version <= '3.4' # py3 trusty
+PyYAML;python_version == '2.7' or python_version >= '3.5'  # all else
+
+MarkupSafe<2.0.0;python_version < '3.6'
+MarkupSafe;python_version >= '3.6' # newer pythons
+
 setuptools<42
 setuptools-scm<=1.17.0
 charmhelpers>=0.4.0,<1.0.0

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,7 +1,8 @@
 # pip is pinned to <19.0 to avoid https://github.com/pypa/pip/issues/6164
 # even with installing setuptools before upgrading pip ends up with pip seeing
 # the older setuptools at the system level if include_system_packages is true
-pip>=18.1,<19.0
+pip>=18.1,<19.0;python_version < '3.8'
+pip;python_version >= '3.8'
 # pin Jinja2, PyYAML and MarkupSafe to the last versions supporting python 3.5
 # for trusty
 Jinja2==2.10;python_version >= '3.0' and python_version <= '3.4' # py3 trusty
@@ -9,15 +10,20 @@ Jinja2==2.11;python_version == '2.7' or python_version == '3.5'  # py27, py35
 Jinja2;python_version >= '3.6' # py36 and on
 
 PyYAML==5.2;python_version >= '3.0' and python_version <= '3.4' # py3 trusty
-PyYAML;python_version == '2.7' or python_version >= '3.5'  # all else
+PyYAML<5.4;python_version == '2.7' or python_version >= '3.5'  # all else
 
 MarkupSafe<2.0.0;python_version < '3.6'
-MarkupSafe;python_version >= '3.6' # newer pythons
+MarkupSafe<2.1.0;python_version == '3.6' # Just for python 3.6
+MarkupSafe;python_version >= '3.7' # newer pythons
 
-setuptools<42
-setuptools-scm<=1.17.0
-charmhelpers>=0.4.0,<1.0.0
+setuptools<42;python_version < '3.8'
+setuptools;python_version >= '3.8'
+setuptools-scm<=1.17.0;python_version < '3.8'
+setuptools-scm;python_version >= '3.8'
+flit_core;python_version >= '3.8'
+charmhelpers>=0.4.0,<2.0.0
 charms.reactive>=0.1.0,<2.0.0
-wheel<0.34
+wheel<0.34;python_version < '3.8'
+wheel;python_version >= '3.8'
 # pin netaddr to avoid pulling importlib-resources
 netaddr<=0.7.19


### PR DESCRIPTION
To ensure compatibility with newer Pythons unpin some requirements
when building in environments with later Pythons.

This resolves compability issues with new Pythons and is OK as
charms can now be build on the Ubuntu release that they will also
run on.