### PR TITLE
Pin pip and setuptools

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -2,7 +2,8 @@
 # even with installing setuptools before upgrading pip ends up with pip seeing
 # the older setuptools at the system level if include_system_packages is true
 pip>=18.1,<19.0;python_version < '3.8'
-pip;python_version >= '3.8'
+# https://github.com/juju-solutions/layer-basic/issues/201
+pip<22.1;python_version >= '3.8'
 # pin Jinja2, PyYAML and MarkupSafe to the last versions supporting python 3.5
 # for trusty
 Jinja2==2.10;python_version >= '3.0' and python_version <= '3.4' # py3 trusty
@@ -17,7 +18,8 @@ MarkupSafe<2.1.0;python_version == '3.6' # Just for python 3.6
 MarkupSafe;python_version >= '3.7' # newer pythons
 
 setuptools<42;python_version < '3.8'
-setuptools;python_version >= '3.8'
+# https://github.com/juju-solutions/layer-basic/issues/201
+setuptools<62.2.0;python_version >= '3.8'
 setuptools-scm<=1.17.0;python_version < '3.8'
 setuptools-scm;python_version >= '3.8'
 flit_core;python_version >= '3.8'


### PR DESCRIPTION
It would be wonderful if we could just have these unpinned and
use the latest and gratest, but unfortunately new releases
routinely bring incompatible and braking changes.

The consequence is released charms breaking after a rebuild, and
more often than you would think we actually encounter changes
in the dependency change between charm CI run and merge, leading
to upload of broken charms to charmhub, which is unacceptable.