### PR TITLE
Pin setuptools-scm for py ge 3.8

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -21,7 +21,8 @@ setuptools<42;python_version < '3.8'
 # https://github.com/juju-solutions/layer-basic/issues/201
 setuptools<62.2.0;python_version >= '3.8'
 setuptools-scm<=1.17.0;python_version < '3.8'
-setuptools-scm;python_version >= '3.8'
+# https://github.com/pypa/setuptools_scm/issues/722
+setuptools-scm<7;python_version >= '3.8'
 flit_core;python_version >= '3.8'
 charmhelpers>=0.4.0,<2.0.0
 charms.reactive>=0.1.0,<2.0.0


### PR DESCRIPTION
Builds are failing due to setuptools_scm issue
722 *1 . To work around this pin setup tools.

*1 https://github.com/pypa/setuptools_scm/issues/722