### PR TITLE
Support installing charms with built wheels

### DIFF
--- a/tests/bundles/minimal.yaml
+++ b/tests/bundles/minimal.yaml
@@ -17,6 +17,10 @@ applications:
     series: focal
     charm: /tmp/charm-builds/minimal
     num_units: 1
+  minimal-binary-wheels-focal:
+    series: focal
+    charm: /tmp/charm-builds/minimal-binary-wheels
+    num_units: 1
   #minimal-no-venv-trusty:
     #series: trusty
     #charm: /tmp/charm-builds/minimal-no-venv

--- a/tox.ini
+++ b/tox.ini
@@ -20,11 +20,13 @@ setenv = CHARM_LAYERS_DIR=/tmp/charm-builds/_tmp/layers
 passenv = HOME
 commands =
     /bin/rm -rf /tmp/charm-builds/_tmp /tmp/charm-builds/minimal
+    /bin/rm -rf /tmp/charm-builds/_tmp /tmp/charm-builds/minimal-binary-wheels
     /bin/rm -rf /tmp/charm-builds/_tmp /tmp/charm-builds/minimal-no-venv
     /bin/mkdir -p /tmp/charm-builds/_tmp/layers
     /bin/bash -c '/bin/ln -sf $(readlink --canonicalize {toxinidir}) /tmp/charm-builds/_tmp/layers/layer-basic'
     /bin/bash -c '/bin/ln -sf $(readlink --canonicalize {toxinidir}/tests/charm-minimal) /tmp/charm-builds/_tmp/layers/charm-minimal'
     charm-build --log-level DEBUG tests/charm-minimal
+    charm-build --log-level DEBUG --binary-wheels -n minimal-binary-wheels tests/charm-minimal
     charm-build --log-level DEBUG tests/charm-minimal-no-venv
     functest-run-suite --keep-model
 


### PR DESCRIPTION
The file naming convention for Python source wheels and built binary wheels are quite different.

Update the code so that it can extract package name and versions from both wheel types.

Signed-off-by: Frode Nordahl <frode.nordahl@canonical.com>