### PR TITLE
Allow PyYAML 6.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python: [3.8, 3.9, "3.10"]
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install Dependencies
+      run: |
+        pip install tox
+    - name: Run lint
+      run: tox -e flake8
+  lint-old-python:
+    name: Lint on older Python versions
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python: [3.5, 3.6, 3.7]
     steps:
     - name: Check out code
       uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,11 @@ envlist = flake8, py3
 skip_missing_interpreters = True
 
 [testenv]
-commands = /bin/bash -c 'py.test -v'
-
+allowlist_externals =
+  /bin/bash
 deps =
     -r{toxinidir}/requirements.txt
+commands = /bin/bash -c 'py.test -v'
 
 [testenv:flake8]
 commands = flake8 reactive lib tests unit_tests
@@ -15,9 +16,17 @@ commands = flake8 reactive lib tests unit_tests
 [testenv:func]
 basepython = python3
 deps = -r{toxinidir}/test-requirements.txt
-whitelist_externals = ln mkdir readlink rm juju
-setenv = CHARM_LAYERS_DIR=/tmp/charm-builds/_tmp/layers
-passenv = HOME
+allowlist_externals =
+  /bin/bash
+  /bin/ln
+  /bin/mkdir
+  /bin/readlink
+  /bin/rm
+  /snap/bin/juju
+setenv =
+  CHARM_LAYERS_DIR=/tmp/charm-builds/_tmp/layers
+passenv =
+  HOME
 commands =
     /bin/rm -rf /tmp/charm-builds/_tmp /tmp/charm-builds/minimal
     /bin/rm -rf /tmp/charm-builds/_tmp /tmp/charm-builds/minimal-binary-wheels

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,8 @@ commands =
 
 
 [flake8]
+# E741: ambiguous variable name
+# W504: # line break after binary operator (have to ignore either this or W503)
 ignore =
-    E741,  # ambiguous variable name
-    W504   # line break after binary operator (have to ignore either this or W503)
+    E741,
+    W504

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -11,7 +11,8 @@ Jinja2==2.11;python_version == '2.7' or python_version == '3.5'  # py27, py35
 Jinja2;python_version >= '3.6' # py36 and on
 
 PyYAML==5.2;python_version >= '3.0' and python_version <= '3.4' # py3 trusty
-PyYAML<5.4;python_version == '2.7' or python_version >= '3.5'  # all else
+PyYAML<5.4;python_version == '2.7' or python_version <= '3.6'  # xenial and bionic
+PyYAML<7.0.0;python_version >= '3.7'  # >= focal
 
 MarkupSafe<2.0.0;python_version < '3.6'
 MarkupSafe<2.1.0;python_version == '3.6' # Just for python 3.6

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -10,6 +10,10 @@ Jinja2==2.10;python_version >= '3.0' and python_version <= '3.4' # py3 trusty
 Jinja2==2.11;python_version == '2.7' or python_version == '3.5'  # py27, py35
 Jinja2;python_version >= '3.6' # py36 and on
 
+# Cython is required to build PyYAML. To find out the supported versions check
+# https://github.com/cython/cython/issues/2800
+Cython
+
 PyYAML==5.2;python_version >= '3.0' and python_version <= '3.4' # py3 trusty
 PyYAML<5.4;python_version == '2.7' or python_version <= '3.6'  # xenial and bionic
 PyYAML<7.0.0;python_version >= '3.7'  # >= focal


### PR DESCRIPTION
ops>=2.1.0 depends on PyYAML-6.x[0], allowing the installation of that version in layer-basic and the charm using layer-basic can lockdown on a more specific version of PyYAML.

It's important to keep reactive charms compatible with the ops framework, because there are compatibility layers to allow the use of interfaces in ops framework based charms[1]

[0] https://github.com/canonical/operator/commit/9162c873592499f512b2ea3908cf9578c0fcc4b8
[1] https://github.com/openstack/charm-interface-hacluster/commit/34b12aa480bc7d6d44699461fa21cb358c5089b4