### PR TITLE
Pin Cython < 3.0 and the rest of the unpinned wheelhouse.txt

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -8,11 +8,11 @@ pip<22.1;python_version >= '3.8'
 # for trusty
 Jinja2==2.10;python_version >= '3.0' and python_version <= '3.4' # py3 trusty
 Jinja2==2.11;python_version == '2.7' or python_version == '3.5'  # py27, py35
-Jinja2;python_version >= '3.6' # py36 and on
+Jinja2<3.2;python_version >= '3.6' # py36 and on
 
 # Cython is required to build PyYAML. To find out the supported versions check
 # https://github.com/cython/cython/issues/2800
-Cython
+Cython<3.0.0
 
 PyYAML==5.2;python_version >= '3.0' and python_version <= '3.4' # py3 trusty
 PyYAML<5.4;python_version == '2.7' or python_version <= '3.6'  # xenial and bionic
@@ -22,7 +22,7 @@ pyaml<23.0.0  # See http://pad.lv/2020788
 
 MarkupSafe<2.0.0;python_version < '3.6'
 MarkupSafe<2.1.0;python_version == '3.6' # Just for python 3.6
-MarkupSafe;python_version >= '3.7' # newer pythons
+MarkupSafe<2.2.0;python_version >= '3.7' # newer pythons
 
 setuptools<42;python_version < '3.8'
 # https://github.com/juju-solutions/layer-basic/issues/201
@@ -30,10 +30,10 @@ setuptools<62.2.0;python_version >= '3.8'
 setuptools-scm<=1.17.0;python_version < '3.8'
 # https://github.com/pypa/setuptools_scm/issues/722
 setuptools-scm<7;python_version >= '3.8'
-flit_core;python_version >= '3.8'
+flit_core<4.0.0;python_version >= '3.8'
 charmhelpers>=0.4.0,<2.0.0
 charms.reactive>=0.1.0,<2.0.0
 wheel<0.34;python_version < '3.8'
-wheel;python_version >= '3.8'
+wheel<1.0;python_version >= '3.8'
 # pin netaddr to avoid pulling importlib-resources
 netaddr<=0.7.19


### PR DESCRIPTION
Pin Cython due to [1], but also to stop future madness, pin the rest of
the wheelhouse.txt to less than next major version. These pins will need
updating from time to time.

The Cython release to 3.0.0 broke pyyaml which (even as of 6.0.1)
requires cython < 3.0.0 to install. This needs pinning here as otherwise
Cython 3.0 gets installed before pyyaml and then it just breaks.

[1] https://github.com/yaml/pyyaml/issues/724
