### PR TITLE
Add flit_scm and anyio pins to wheelhouse

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -31,6 +31,8 @@ setuptools-scm<=1.17.0;python_version < '3.8'
 # https://github.com/pypa/setuptools_scm/issues/722
 setuptools-scm<7;python_version >= '3.8'
 flit_core<4.0.0;python_version >= '3.8'
+flit_scm<=1.7.0;python_version >= '3.8'
+anyio<3.7.0;python_version >= '3.8'
 charmhelpers>=0.4.0,<2.0.0
 charms.reactive>=0.1.0,<2.0.0
 wheel<0.34;python_version < '3.8'


### PR DESCRIPTION
flit_scm is required by exceptiongroup.
anyio is pinned to prevent requiring setuptools >= 64.
    
Fixes #218